### PR TITLE
Fix/vector_casting

### DIFF
--- a/src/CP/constraints/alldifferent.jl
+++ b/src/CP/constraints/alldifferent.jl
@@ -8,7 +8,7 @@ include("algorithms/matching.jl")
 end
 
 """
-    AllDifferent(x::Vector{SeaPearl.AbstractIntVar}, trailer)
+    AllDifferent(x::Vector{<:AbstractIntVar}, trailer)
 
 AllDifferent constraint, enforcing ∀ i ≠ j ∈ ⟦1, length(x)⟧, x[i] ≠ x[j].
 
@@ -18,7 +18,7 @@ Many of the functions below relate to algorithms depicted in the paper, and thei
 documentation refer to parts of the overall algorithm.
 """
 struct AllDifferent <: Constraint
-    x::Vector{SeaPearl.AbstractIntVar}
+    x::Vector{<:AbstractIntVar}
     active::StateObject{Bool}
     initialized::StateObject{Bool}
     matching::Vector{StateObject{Pair{Int, Int}}}
@@ -27,7 +27,7 @@ struct AllDifferent <: Constraint
     numberOfVars::Int
     numberOfVals::Int
 
-    function AllDifferent(x::Vector{SeaPearl.AbstractIntVar}, trailer)::AllDifferent
+    function AllDifferent(x::Vector{<:AbstractIntVar}, trailer)::AllDifferent
         max = Base.maximum(var -> maximum(var.domain), x)
         min = Base.minimum(var -> minimum(var.domain), x)
         range = max - min + 1
@@ -300,9 +300,6 @@ function propagate!(constraint::AllDifferent, toPropagate::Set{Constraint}, prun
     end
     return true
 end
-
-AllDifferent(x::Vector{IntVar}, trailer) = AllDifferent(Vector{AbstractIntVar}(x), trailer)
-AllDifferent(x::Vector{IntVarView}, trailer) = AllDifferent(Vector{AbstractIntVar}(x), trailer)
 
 variableArray(constraint::AllDifferent) = constraint.x
 

--- a/src/CP/constraints/constraints.jl
+++ b/src/CP/constraints/constraints.jl
@@ -37,7 +37,7 @@ addOnDomainChange!(x::Union{IntVarView, BoolVarView}, constraint::Constraint) = 
 
 Add the constraints to `toPropagate` only if they are active.
 """
-function addToPropagate!(toPropagate::Set{Constraint}, constraints::Array{Constraint})
+function addToPropagate!(toPropagate::Set{<:Constraint}, constraints::Array{<:Constraint})
     for constraint in constraints
         if constraint.active.value
             push!(toPropagate, constraint)
@@ -50,6 +50,6 @@ end
 
 Add the constraints that have to be propagated when the domain of `x` changes to `toPropagate`.
 """
-triggerDomainChange!(toPropagate::Set{Constraint}, x::Union{AbstractIntVar, AbstractBoolVar, IntSetVar}) = addToPropagate!(toPropagate, getOnDomainChange(x))
+triggerDomainChange!(toPropagate::Set{<:Constraint}, x::Union{AbstractIntVar, AbstractBoolVar, IntSetVar}) = addToPropagate!(toPropagate, getOnDomainChange(x))
 getOnDomainChange(x::Union{IntVar, BoolVar, IntSetVar}) = x.onDomainChange
 getOnDomainChange(x::Union{IntVarView, BoolVarView}) = getOnDomainChange(x.x)

--- a/src/CP/constraints/sumgreaterthan.jl
+++ b/src/CP/constraints/sumgreaterthan.jl
@@ -1,16 +1,16 @@
 """
-    SumGreaterThan(x::SeaPearl.AbstractIntVar, v::Int)
+    SumGreaterThan(x<:AbstractIntVar, v::Int)
 
 Summing constraint, states that `x[1] + x[2] + ... + x[length(x)] >= lower`
 """
 struct SumGreaterThan <: Constraint
-    x                   ::Array{AbstractIntVar}
+    x                   ::Array{<:AbstractIntVar}
     lower               ::Int
     active              ::StateObject{Bool}
     numberOfFreeVars    ::StateObject{Int}
     sumOfFixedVars      ::StateObject{Int}
     freeIds             ::Array{Int}
-    function SumGreaterThan(x::Array{AbstractIntVar}, lower, trailer)
+    function SumGreaterThan(x::Array{<:AbstractIntVar}, lower, trailer)
         @assert !isempty(x)
 
         freeIds = zeros(length(x))

--- a/src/CP/constraints/sumlessthan.jl
+++ b/src/CP/constraints/sumlessthan.jl
@@ -1,16 +1,16 @@
 """
-    SumLessThan(x::SeaPearl.AbstractIntVar, v::Int)
+    SumLessThan(x<:AbstractIntVar, v::Int)
 
 Summing constraint, states that `x[1] + x[2] + ... + x[length(x)] <= v`
 """
 struct SumLessThan <: Constraint
-    x                   ::Array{AbstractIntVar}
+    x                   ::Array{<:AbstractIntVar}
     upper               ::Int
     active              ::StateObject{Bool}
     numberOfFreeVars    ::StateObject{Int}
     sumOfFixedVars      ::StateObject{Int}
     freeIds             ::Array{Int}
-    function SumLessThan(x::Array{AbstractIntVar}, upper,  trailer)
+    function SumLessThan(x::Array{<:AbstractIntVar}, upper,  trailer)
         @assert !isempty(x)
 
         freeIds = zeros(length(x))

--- a/src/CP/constraints/sumtozero.jl
+++ b/src/CP/constraints/sumtozero.jl
@@ -1,15 +1,15 @@
 """
-    SumToZero(x::SeaPearl.AbstractIntVar, v::Int)
+    SumToZero(x<:AbstractIntVar, v::Int)
 
 Summing constraint, states that `x[1] + x[2] + ... + x[length(x)] == 0`
 """
 struct SumToZero <: Constraint
-    x                   ::Array{AbstractIntVar}
+    x                   ::Array{<:AbstractIntVar}
     active              ::StateObject{Bool}
     numberOfFreeVars    ::StateObject{Int}
     sumOfFixedVars      ::StateObject{Int}
     freeIds             ::Array{Int}
-    function SumToZero(x::Array{AbstractIntVar}, trailer)
+    function SumToZero(x::Array{<:AbstractIntVar}, trailer)
         @assert !isempty(x)
 
         freeIds = zeros(length(x))

--- a/test/CP/constraints/alldifferent.jl
+++ b/test/CP/constraints/alldifferent.jl
@@ -6,7 +6,7 @@ using LightGraphs
         x = SeaPearl.IntVar(1, 3, "x", trailer)
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         z = SeaPearl.IntVar(2, 3, "Z", trailer)
-        vec = Vector{SeaPearl.AbstractIntVar}([x, y, z])
+        vec = Vector{SeaPearl.IntVar}([x, y, z])
 
         constraint = SeaPearl.AllDifferent(vec, trailer)
 
@@ -27,7 +27,7 @@ using LightGraphs
         x = SeaPearl.IntVar(1, 3, "x", trailer)
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         z = SeaPearl.IntVar(2, 3, "Z", trailer)
-        vec = Vector{SeaPearl.AbstractIntVar}([x, y, z])
+        vec = Vector{SeaPearl.IntVar}([x, y, z])
 
         constraint = SeaPearl.AllDifferent(vec, trailer)
         SeaPearl.setValue!(constraint.edgesState[Edge(1, 6)], SeaPearl.removed)
@@ -86,7 +86,7 @@ using LightGraphs
         SeaPearl.remove!(a.domain, 3)
         b = SeaPearl.IntVar(3, 6, "b", trailer)
         c = SeaPearl.IntVar(6, 7, "c", trailer)
-        vars = Vector{SeaPearl.AbstractIntVar}([x, y, z, a, b, c])
+        vars = [x, y, z, a, b, c]
         constraint = SeaPearl.AllDifferent(vars, trailer)
 
         graph, digraph = SeaPearl.initializeGraphs!(constraint)
@@ -205,19 +205,19 @@ using LightGraphs
         trailer = SeaPearl.Trailer()
         model = SeaPearl.CPModel(trailer)
 
-        rows = Vector{SeaPearl.AbstractIntVar}(undef, n)
+        rows = Vector{SeaPearl.IntVar}(undef, n)
         for i = 1:n
             rows[i] = SeaPearl.IntVar(1, n, "row_"*string(i), trailer)
             SeaPearl.addVariable!(model, rows[i]; branchable=true)
         end
 
-        rows_plus = Vector{SeaPearl.AbstractIntVar}(undef, n)
+        rows_plus = Vector{SeaPearl.IntVarView}(undef, n)
         for i = 1:n
             rows_plus[i] = SeaPearl.IntVarViewOffset(rows[i], i, rows[i].id*"+"*string(i))
             #SeaPearl.addVariable!(model, rows_plus[i]; branchable=false)
         end
 
-        rows_minus = Vector{SeaPearl.AbstractIntVar}(undef, n)
+        rows_minus = Vector{SeaPearl.IntVarView}(undef, n)
         for i = 1:n
             rows_minus[i] = SeaPearl.IntVarViewOffset(rows[i], -i, rows[i].id*"-"*string(i))
             #SeaPearl.addVariable!(model, rows_minus[i]; branchable=false)
@@ -228,7 +228,7 @@ using LightGraphs
         push!(model.constraints, SeaPearl.AllDifferent(rows_minus, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
-        status = @time SeaPearl.solve!(model; variableHeuristic=variableSelection)
+        status = SeaPearl.solve!(model; variableHeuristic=variableSelection)
 
         @test status == :Optimal
         @test length(model.solutions) == 10
@@ -261,7 +261,7 @@ using LightGraphs
         push!(model.constraints, SeaPearl.AllDifferent(rows_minus, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
-        status = @time SeaPearl.solve!(model; variableHeuristic=variableSelection)
+        status = SeaPearl.solve!(model; variableHeuristic=variableSelection)
 
         @test status == :Optimal
         @test length(model.solutions) == 40

--- a/test/CP/constraints/sumgreaterthan.jl
+++ b/test/CP/constraints/sumgreaterthan.jl
@@ -3,16 +3,12 @@ using SeaPearl
 @testset "sumgreaterthan.jl" begin
     @testset "SumGreaterThan()" begin
         trailer = SeaPearl.Trailer()
-        vars = SeaPearl.AbstractIntVar[]
 
         x = SeaPearl.IntVar(2, 6, "x", trailer)
-        push!(vars, x)
         y = SeaPearl.IntVar(2, 3, "y", trailer)
-        push!(vars, y)
         ax = SeaPearl.IntVarViewMul(x, 3, "3x")
-        push!(vars, ax)
         minusY = SeaPearl.IntVarViewOpposite(y, "-y")
-        push!(vars, minusY)
+        vars = [x, y, ax, minusY]
         constraint = SeaPearl.SumGreaterThan(vars, 10, trailer)
 
         @test constraint in x.onDomainChange

--- a/test/CP/constraints/sumlessthan.jl
+++ b/test/CP/constraints/sumlessthan.jl
@@ -3,16 +3,12 @@ using SeaPearl
 @testset "sumlessthan.jl" begin
     @testset "SumLessThan()" begin
         trailer = SeaPearl.Trailer()
-        vars = SeaPearl.AbstractIntVar[]
 
         x = SeaPearl.IntVar(2, 6, "x", trailer)
-        push!(vars, x)
         y = SeaPearl.IntVar(2, 3, "y", trailer)
-        push!(vars, y)
         ax = SeaPearl.IntVarViewMul(x, 3, "3x")
-        push!(vars, ax)
         minusY = SeaPearl.IntVarViewOpposite(y, "-y")
-        push!(vars, minusY)
+        vars = [x, y, ax, minusY]
         constraint = SeaPearl.SumLessThan(vars, 10, trailer)
 
         @test constraint in x.onDomainChange

--- a/test/CP/constraints/sumtozero.jl
+++ b/test/CP/constraints/sumtozero.jl
@@ -3,16 +3,12 @@ using SeaPearl
 @testset "sumtozero.jl" begin
     @testset "SumToZero()" begin
         trailer = SeaPearl.Trailer()
-        vars = SeaPearl.AbstractIntVar[]
 
         x = SeaPearl.IntVar(2, 6, "x", trailer)
-        push!(vars, x)
         y = SeaPearl.IntVar(2, 3, "y", trailer)
-        push!(vars, y)
         ax = SeaPearl.IntVarViewMul(x, 3, "3x")
-        push!(vars, ax)
         minusY = SeaPearl.IntVarViewOpposite(y, "-y")
-        push!(vars, minusY)
+        vars = [x, y, ax, minusY]
         constraint = SeaPearl.SumToZero(vars, trailer)
 
         @test constraint in x.onDomainChange


### PR DESCRIPTION
Small modification to make it possible for constraints using vector of variables to use any `Vector{T}` where `T<:AbstractIntVar` as input.

Closes #118 