### PR TITLE
Removed extra dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,13 @@ authors = ["Ilan Coulon", "Félix Chalumeau"]
 version = "0.2.0"
 
 [deps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 GeometricFlux = "7e08b658-56d3-11e9-2997-919d5b31e4ea"
-GraphPlot = "a2cc645c-3eea-5389-862e-a155d0052231"
 GraphSignals = "3ebe565e-a4b5-49c6-aed2-300248c3a9c1"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-LanguageServer = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -25,7 +20,6 @@ ReinforcementLearning = "158674fc-8238-5cab-b5ba-03dfc80d1318"
 ReinforcementLearningBase = "e575027e-6cd6-5018-9292-cdc6200d2b44"
 ReinforcementLearningCore = "de1b191a-4ae0-4afa-a27b-92d07f46b2d6"
 ReinforcementLearningZoo = "d607f57d-ee1e-4ba7-bcf2-7734c1e31854"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -52,6 +46,7 @@ Zygote = "~0.5, 0.6"
 julia = "1.6"
 
 [extras]
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]


### PR DESCRIPTION
Some extra dependencies have been recently added to SeaPearl by mistake, but aren't needed anywhere.
I propose to remove:

- Gadfly
- GraphPlot
- JuliaFormatter
- LanguageServer
- CUDA (it was installed before, but it is useless as long as we don't handle GPU computation. It will be needed later, but we shouldn't have it as a dependency for the time being, as it poses issues with other packages)