### PR TITLE
Compact Table optimization

### DIFF
--- a/src/CP/constraints/compacttable.jl
+++ b/src/CP/constraints/compacttable.jl
@@ -31,7 +31,8 @@ Create a CompactTable constraint from the `variables`, with values given in `tab
 
 This constructor gives full control on both `table` and `supports`. The attributes are not duplicated and remains
 linked to the variables given to the constructor. It should be used only to avoid duplication of `table` when using
-the same table constraint many times with different variables.
+the same table constraint many times with different variables. *WARNING*: all variables must have the same domain; 
+`table` and `supports` must be cleaned.
 
 # Arguments
 - `variables::Vector{<:AbstractIntVar}`: vector of variables of size (n, ).
@@ -207,12 +208,7 @@ function buildResidues(supports::Dict{Pair{Int,Int},BitVector})::Dict{Pair{Int,I
     residues = Dict{Pair{Int,Int},Int}()
     n = 64
     for (key, support) in supports
-        index = findfirst(support)
-        if isnothing(index)
-            residues[key] = 1
-        else
-            residues[key] = Int(ceil(index/n))
-        end
+        residues[key] = Int(ceil(findfirst(support)/n))
     end
     return residues
 end

--- a/src/CP/constraints/compacttable.jl
+++ b/src/CP/constraints/compacttable.jl
@@ -82,6 +82,8 @@ end
 
 Create a CompactTable constraint from the `variables`, with values given in `table`.
 
+This is the recommended constructor, as it safely builds the constraint and isolates it. If you choose any of the 2 other constructor,
+beware how you create your attributes, and be sure not to modify them at any time.
 
 # Arguments
 - `variables::Vector{<:AbstractIntVar}`: vector of variables of size (n, ).

--- a/test/CP/constraints/compacttable.jl
+++ b/test/CP/constraints/compacttable.jl
@@ -46,6 +46,30 @@
         SeaPearl.cleanSupports!(support, vec)
         @test !(1 in x.domain)
     end
+    @testset "TableConstraint(variables::Vector{<:AbstractIntVar}, table::Matrix{Int}, supports::Dict{Pair{Int,Int},BitVector}, trailer)" begin
+        trailer = SeaPearl.Trailer()
+        x = SeaPearl.IntVar(1, 3, "x", trailer)
+        y = SeaPearl.IntVar(1, 3, "y", trailer)
+        z = SeaPearl.IntVar(1, 3, "Z", trailer)
+        vec1 = [x, y, z]
+        vec2 = [z, y, x]
+        table = [
+            1 2 2;
+            3 3 3;
+            1 2 3
+        ]
+        supports = SeaPearl.buildSupport(vec1, table)
+        constraint1 = SeaPearl.TableConstraint(vec1, table, supports, trailer)
+        constraint2 = SeaPearl.TableConstraint(vec2, table, supports, trailer)
+        @test size(constraint1.table, 2)==3
+        @test size(constraint2.table, 2)==3
+        @test (constraint1.supports[3=>2] == [0,1,0])
+        @test (constraint2.supports[3=>2] == [0,1,0])
+        @test(isempty(constraint1.modifiedVariables))
+        @test(isempty(constraint2.modifiedVariables))
+        @test(constraint1.residues[3=>2]==1)
+        @test(constraint2.residues[3=>2]==1)
+    end
     @testset "TableConstraint(variables::Vector{<:AbstractIntVar}, table::Matrix{Int}, trailer)" begin
         trailer = SeaPearl.Trailer()
         x = SeaPearl.IntVar(1, 3, "x", trailer)

--- a/test/CP/constraints/compacttable.jl
+++ b/test/CP/constraints/compacttable.jl
@@ -59,6 +59,8 @@
             1 2 3
         ]
         supports = SeaPearl.buildSupport(vec1, table)
+        SeaPearl.cleanSupports!(supports, vec1)
+        table = SeaPearl.cleanTable(vec1, table)
         constraint1 = SeaPearl.TableConstraint(vec1, table, supports, trailer)
         constraint2 = SeaPearl.TableConstraint(vec2, table, supports, trailer)
         @test size(constraint1.table, 2)==3


### PR DESCRIPTION
This is the new constructor proposed in #137 with the associated testset.

I first changed the function `buildResidues` as some supports weren't present in the table when initializing the constraint. But then I figured it would be more efficient to give the constraint already cleaned versions of the supports and table. 

The counterpart is that between different instances of the constraint sharing the same instances of `table`/`supports`, the variables should initially have the same domains (otherwise the support will be setup incorrectly for some instances).

To sum up, this new constructor gives much more freedom to the user but should be well understood in order not to tigger errors.

Closes #137 