### PR TITLE
CPModification upgrade

### DIFF
--- a/src/CP/constraints/absolute.jl
+++ b/src/CP/constraints/absolute.jl
@@ -10,6 +10,7 @@ struct Absolute <: Constraint
 
     function Absolute(x, y, trailer)
         constraint = new(x, y, StateObject(true, trailer))
+        # TODO fix domain change
         removeBelow!(y.domain, 0) # y cannot take a negative value
         addOnDomainChange!(x, constraint)
         addOnDomainChange!(y, constraint)

--- a/src/CP/constraints/absolute.jl
+++ b/src/CP/constraints/absolute.jl
@@ -27,11 +27,11 @@ function propagate!(constraint::Absolute, toPropagate::Set{Constraint}, prunedDo
 
     if !constraint.initialized.value
         setValue!(constraint.initialized, true)
-        prunedY = removeBelow!(y.domain, 0) # y cannot take a negative value
-        addToPrunedDomains!(prunedDomains, y, prunedY)
-        triggerDomainChange!(toPropagate, y)
+        prunedY = removeBelow!(constraint.y.domain, 0) # y cannot take a negative value
+        addToPrunedDomains!(prunedDomains, constraint.y, prunedY)
+        triggerDomainChange!(toPropagate, constraint.y)
     end
-    
+
     if isbound(constraint.x) 
         value = abs(assignedValue(constraint.x))
         if !(value in constraint.y.domain)

--- a/src/CP/constraints/absolute.jl
+++ b/src/CP/constraints/absolute.jl
@@ -103,9 +103,9 @@ variablesArray(constraint::Absolute) = [constraint.x, constraint.y]
 function Base.show(io::IO, ::MIME"text/plain", con::Absolute)
     println(io, string(typeof(con)), ": |", con.x.id, "| = ", con.y.id, ", active = ", con.active.value)
     println(io, "   ", con.x)
-    println(io, "   ", con.y)
+    print(io, "   ", con.y)
 end
 
 function Base.show(io::IO, con::Absolute)
-    println(io, string(typeof(con)), ": |", con.x.id, "| = ", con.y.id, ", active = ", con.active.value)
+    print(io, string(typeof(con)), ": |", con.x.id, "| = ", con.y.id)
 end

--- a/src/CP/constraints/alldifferent.jl
+++ b/src/CP/constraints/alldifferent.jl
@@ -304,12 +304,12 @@ end
 variableArray(constraint::AllDifferent) = constraint.x
 
 function Base.show(io::IO, ::MIME"text/plain", con::AllDifferent)
-    println(io, string(typeof(con)), ": ", join([var.id for var in con.x], " != "), ", active = ", con.active)
+    print(io, string(typeof(con)), ": ", join([var.id for var in con.x], " != "), ", active = ", con.active)
     for var in con.x
-        println(io, "   ", var)
+        print(io, "\n   ", var)
     end
 end
 
 function Base.show(io::IO, con::AllDifferent)
-    println(io, string(typeof(con)), ": ", join([var.id for var in con.x], " != "))
+    print(io, string(typeof(con)), ": ", join([var.id for var in con.x], " != "))
 end

--- a/src/CP/constraints/binarymaximum.jl
+++ b/src/CP/constraints/binarymaximum.jl
@@ -77,5 +77,5 @@ function Base.show(io::IO, ::MIME"text/plain", con::BinaryMaximumBC)
 end
 
 function Base.show(io::IO, con::BinaryMaximumBC)
-    print(io, typeof(con), ": ", con.x.id, " == max(", con.y.id, con.z.id, ")")
+    print(io, typeof(con), ": ", con.x.id, " == max(", con.y.id, ", ", con.z.id, ")")
 end

--- a/src/CP/constraints/inset.jl
+++ b/src/CP/constraints/inset.jl
@@ -41,7 +41,7 @@ function propagate!(constraint::InSet, toPropagate::Set{Constraint}, prunedDomai
     if isbound(constraint.x)
         if !is_required(constraint.s.domain, assignedValue(constraint.x))
             require!(constraint.s.domain, assignedValue(constraint.x))
-            # TODO log modifications on s
+            addToPrunedDomains!(prunedDomains, s, SetModification(;required=[assignedValue(constraint.x)]))
             triggerDomainChange!(toPropagate, constraint.s)
         end
     end

--- a/src/CP/constraints/inset.jl
+++ b/src/CP/constraints/inset.jl
@@ -41,6 +41,7 @@ function propagate!(constraint::InSet, toPropagate::Set{Constraint}, prunedDomai
     if isbound(constraint.x)
         if !is_required(constraint.s.domain, assignedValue(constraint.x))
             require!(constraint.s.domain, assignedValue(constraint.x))
+            # TODO log modifications on s
             triggerDomainChange!(toPropagate, constraint.s)
         end
     end

--- a/src/CP/constraints/inset.jl
+++ b/src/CP/constraints/inset.jl
@@ -41,7 +41,7 @@ function propagate!(constraint::InSet, toPropagate::Set{Constraint}, prunedDomai
     if isbound(constraint.x)
         if !is_required(constraint.s.domain, assignedValue(constraint.x))
             require!(constraint.s.domain, assignedValue(constraint.x))
-            addToPrunedDomains!(prunedDomains, s, SetModification(;required=[assignedValue(constraint.x)]))
+            addToPrunedDomains!(prunedDomains, constraint.s, SetModification(;required=[assignedValue(constraint.x)]))
             triggerDomainChange!(toPropagate, constraint.s)
         end
     end

--- a/src/CP/constraints/islessorequal.jl
+++ b/src/CP/constraints/islessorequal.jl
@@ -1,15 +1,14 @@
+"""
+isLessOrEqual(b::AbstractBoolVar, x::AbstractIntVar, y::AbstractIntVar, trailer::Trailer)
 
+Equivalence between a boolean variable and the inequality between variables, states that `b ⟺ x ≤ y`
+"""
 struct isLessOrEqual <: Constraint
     b       ::AbstractBoolVar
     x       ::AbstractIntVar
     y       ::AbstractIntVar
     active  ::StateObject{Bool}
 
-    """
-        isLessOrEqual(b::AbstractBoolVar, x::AbstractIntVar, y::AbstractIntVar, trailer::Trailer)
-
-    Equivalence between a boolean variable and the inequality between variables, states that `b <=> x <= y`
-    """
     function isLessOrEqual(b, x, y, trailer)
         constraint = new(b, x, y, StateObject(true, trailer))
         addOnDomainChange!(b, constraint)

--- a/src/CP/constraints/reifiedinset.jl
+++ b/src/CP/constraints/reifiedinset.jl
@@ -52,6 +52,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             if isbound(constraint.x)
                 if !is_required(constraint.s.domain, assignedValue(constraint.x))
                     require!(constraint.s.domain, assignedValue(constraint.x))
+                    # TODO log modifications in s
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end
@@ -70,6 +71,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             if isbound(constraint.x)
                 if is_possible(constraint.s.domain, assignedValue(constraint.x))
                     exclude!(constraint.s.domain, assignedValue(constraint.x))
+                    # TODO log modifications in s
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end

--- a/src/CP/constraints/reifiedinset.jl
+++ b/src/CP/constraints/reifiedinset.jl
@@ -70,7 +70,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             # Filter s
             if isbound(constraint.x)
                 if is_possible(constraint.s.domain, assignedValue(constraint.x))
-                    exclude!(constrain.domain, assignedValue(constraint.x))
+                    exclude!(constraint.s.domain, assignedValue(constraint.x))
                     addToPrunedDomains!(prunedDomains, constraint.s, SetModification(;excluded=[assignedValue(constraint.x)]))
                     triggerDomainChange!(toPropagate, constraint.s)
                 end

--- a/src/CP/constraints/reifiedinset.jl
+++ b/src/CP/constraints/reifiedinset.jl
@@ -52,7 +52,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             if isbound(constraint.x)
                 if !is_required(constraint.s.domain, assignedValue(constraint.x))
                     require!(constraint.s.domain, assignedValue(constraint.x))
-                    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=[assignedValue(constraint.x)]))
+                    addToPrunedDomains!(prunedDomains, constraint.s, SetModification(;excluded=[assignedValue(constraint.x)]))
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end
@@ -71,7 +71,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             if isbound(constraint.x)
                 if is_possible(constraint.s.domain, assignedValue(constraint.x))
                     exclude!(constrain.domain, assignedValue(constraint.x))
-                    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=[assignedValue(constraint.x)]))
+                    addToPrunedDomains!(prunedDomains, constraint.s, SetModification(;excluded=[assignedValue(constraint.x)]))
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end

--- a/src/CP/constraints/reifiedinset.jl
+++ b/src/CP/constraints/reifiedinset.jl
@@ -52,7 +52,7 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             if isbound(constraint.x)
                 if !is_required(constraint.s.domain, assignedValue(constraint.x))
                     require!(constraint.s.domain, assignedValue(constraint.x))
-                    # TODO log modifications in s
+                    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=[assignedValue(constraint.x)]))
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end
@@ -70,8 +70,8 @@ function propagate!(constraint::ReifiedInSet, toPropagate::Set{Constraint}, prun
             # Filter s
             if isbound(constraint.x)
                 if is_possible(constraint.s.domain, assignedValue(constraint.x))
-                    exclude!(constraint.s.domain, assignedValue(constraint.x))
-                    # TODO log modifications in s
+                    exclude!(constrain.domain, assignedValue(constraint.x))
+                    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=[assignedValue(constraint.x)]))
                     triggerDomainChange!(toPropagate, constraint.s)
                 end
             end

--- a/src/CP/constraints/setdiffsingleton.jl
+++ b/src/CP/constraints/setdiffsingleton.jl
@@ -37,7 +37,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(b.domain, v)
-        # TODO log modifications in b
+        addToPrunedDomains!(prunedDomains, b, SetModification(;excluded=[v]))
         triggerDomainChange!(toPropagate, b)
     end
 
@@ -47,7 +47,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
             if is_possible(a.domain, v)
                 if !is_required(a.domain, v)
                     require!(a.domain, v)
-                    # TODO log modifications in a
+                    addToPrunedDomains!(prunedDomains, a, SetModification(;required=[v]))
                     triggerDomainChange!(toPropagate, a)
                 end
             else
@@ -77,7 +77,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(a.domain, v)
-        # TODO log modifications in a
+        addToPrunedDomains!(prunedDomains, a, SetModification(;excluded=[v]))
         triggerDomainChange!(toPropagate, a)
     end
 
@@ -86,7 +86,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
         if is_possible(b.domain, v)
             if !is_required(b.domain, v)
                 require!(b.domain, v)
-                # TODO log modifications in b
+                addToPrunedDomains!(prunedDomains, b, SetModification(;required=[v]))
                 triggerDomainChange!(toPropagate, b)
             end
         else
@@ -105,7 +105,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
         if is_possible(a.domain, v)
             if !is_required(a.domain, v)
                 exclude!(a.domain, v)
-                # TODO log modifications in a
+                addToPrunedDomains!(prunedDomains, a, SetModification(;excluded=[v]))
                 triggerDomainChange!(toPropagate, a)
             else
                 return false

--- a/src/CP/constraints/setdiffsingleton.jl
+++ b/src/CP/constraints/setdiffsingleton.jl
@@ -37,6 +37,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(b.domain, v)
+        # TODO log modifications in b
         triggerDomainChange!(toPropagate, b)
     end
 
@@ -46,6 +47,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
             if is_possible(a.domain, v)
                 if !is_required(a.domain, v)
                     require!(a.domain, v)
+                    # TODO log modifications in a
                     triggerDomainChange!(toPropagate, a)
                 end
             else
@@ -75,6 +77,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(a.domain, v)
+        # TODO log modifications in a
         triggerDomainChange!(toPropagate, a)
     end
 
@@ -83,6 +86,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
         if is_possible(b.domain, v)
             if !is_required(b.domain, v)
                 require!(b.domain, v)
+                # TODO log modifications in b
                 triggerDomainChange!(toPropagate, b)
             end
         else
@@ -101,6 +105,7 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
         if is_possible(a.domain, v)
             if !is_required(a.domain, v)
                 exclude!(a.domain, v)
+                # TODO log modifications in a
                 triggerDomainChange!(toPropagate, a)
             else
                 return false

--- a/src/CP/constraints/setdiffsingleton.jl
+++ b/src/CP/constraints/setdiffsingleton.jl
@@ -37,7 +37,9 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(b.domain, v)
-        addToPrunedDomains!(prunedDomains, b, SetModification(;excluded=[v]))
+    end
+    if !isempty(toRemove)
+        addToPrunedDomains!(prunedDomains, b, SetModification(;excluded=copy(toRemove)))
         triggerDomainChange!(toPropagate, b)
     end
 
@@ -77,7 +79,9 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
     end
     for v in toRemove
         exclude!(a.domain, v)
-        addToPrunedDomains!(prunedDomains, a, SetModification(;excluded=[v]))
+    end
+    if !isempty(toRemove)
+        addToPrunedDomains!(prunedDomains, a, SetModification(;excluded=copy(toRemove)))
         triggerDomainChange!(toPropagate, a)
     end
 
@@ -118,6 +122,10 @@ function propagate!(constraint::SetDiffSingleton, toPropagate::Set{Constraint}, 
         if (isbound(a) && isbound(b)) || possible_not_required_values(b.domain) == Set{Int}([assignedValue(x)])
             setValue!(constraint.active, false)
         end
+    end
+
+    if constraint in toPropagate
+        pop!(toPropagate, constraint)
     end
 
     return !isempty(x.domain)

--- a/src/CP/constraints/setequalconstant.jl
+++ b/src/CP/constraints/setequalconstant.jl
@@ -30,7 +30,7 @@ function propagate!(constraint::SetEqualConstant, toPropagate::Set{Constraint}, 
     end
 
     exclude_all!(constraint.s.domain)
-
+    # TODO log modifications in s
     triggerDomainChange!(toPropagate, constraint.s)
 
     setValue!(constraint.active, false)

--- a/src/CP/constraints/setequalconstant.jl
+++ b/src/CP/constraints/setequalconstant.jl
@@ -29,8 +29,8 @@ function propagate!(constraint::SetEqualConstant, toPropagate::Set{Constraint}, 
         end
     end
 
-    exclude_all!(constraint.s.domain)
-    # TODO log modifications in s
+    excluded = exclude_all!(constraint.s.domain)
+    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=excluded))
     triggerDomainChange!(toPropagate, constraint.s)
 
     setValue!(constraint.active, false)

--- a/src/CP/constraints/setequalconstant.jl
+++ b/src/CP/constraints/setequalconstant.jl
@@ -30,7 +30,7 @@ function propagate!(constraint::SetEqualConstant, toPropagate::Set{Constraint}, 
     end
 
     excluded = exclude_all!(constraint.s.domain)
-    addToPrunedDomains!(prunedDomains, s, SetModification(;excluded=excluded))
+    addToPrunedDomains!(prunedDomains, constraint.s, SetModification(;excluded=excluded))
     triggerDomainChange!(toPropagate, constraint.s)
 
     setValue!(constraint.active, false)

--- a/src/CP/constraints/sumgreaterthan.jl
+++ b/src/CP/constraints/sumgreaterthan.jl
@@ -87,7 +87,7 @@ function Base.show(io::IO, ::MIME"text/plain", con::SumGreaterThan)
     ids = [var.id for var in con.x]
     print(io, typeof(con), ": ", join(ids, " + "), " ≥ ", con.lower, ", active = ", con.active)
     for var in con.x
-        print(io, "\n   ", con.var)
+        print(io, "\n   ", var)
     end
 end
 

--- a/src/CP/constraints/sumlessthan.jl
+++ b/src/CP/constraints/sumlessthan.jl
@@ -87,7 +87,7 @@ function Base.show(io::IO, ::MIME"text/plain", con::SumLessThan)
     ids = [var.id for var in con.x]
     print(io, typeof(con), ": ", join(ids, " + "), " ≤ ", con.upper, ", active = ", con.active)
     for var in con.x
-        print(io, "\n   ", con.var)
+        print(io, "\n   ", var)
     end
 end
 

--- a/src/CP/core/model.jl
+++ b/src/CP/core/model.jl
@@ -40,7 +40,7 @@ end
 
 CPModel() = CPModel(Trailer())
 
-const CPModification = Dict{String, Union{Array{Int}, SetModification}}
+const CPModification = Dict{String, Union{Array{Int}, Array{Bool}, SetModification}}
 
 """
     addVariable!(model::CPModel, x::AbstractVar; branchable=true)
@@ -110,9 +110,9 @@ function addToPrunedDomains!(prunedDomains::CPModification, x::Union{AbstractInt
         return
     end
     if haskey(prunedDomains, x.id)
-        prunedDomains[x.id] = vcat(prunedDomains[x.id], pruned)
+        prunedDomains[x.id] = vcat(prunedDomains[x.id], Array(pruned))
     else
-        prunedDomains[x.id] = pruned
+        prunedDomains[x.id] = Array(pruned)
     end
 end
 
@@ -126,13 +126,13 @@ Update the `CPModification` by adding modified set values.
 - `x::IntSetVar`: the variable that had its values changed.
 - `modification::SetModification`: the modified values.
 """
-function addToPrunedDomains!!(prunedDomains::CPModification, x::IntSetVar, modification::SetModification)
+function addToPrunedDomains!(prunedDomains::CPModification, x::IntSetVar, modification::SetModification)
     if isempty(modification.required) && isempty(modification.excluded)
         return
     end
 
     if haskey(prunedDomains, x.id)
-        merge!(prunedDomains[x.id], modification)
+        mergeSetModifications!(prunedDomains[x.id], modification)
     else
         prunedDomains[x.id] = modification
     end

--- a/src/CP/core/model.jl
+++ b/src/CP/core/model.jl
@@ -40,6 +40,7 @@ end
 
 CPModel() = CPModel(Trailer())
 
+# TODO  add SetModification
 const CPModification = Dict{String, Array{Int}}
 
 """

--- a/src/CP/core/model.jl
+++ b/src/CP/core/model.jl
@@ -40,8 +40,7 @@ end
 
 CPModel() = CPModel(Trailer())
 
-# TODO  add SetModification
-const CPModification = Dict{String, Array{Int}}
+const CPModification = Dict{String, Union{Array{Int}, SetModification}}
 
 """
     addVariable!(model::CPModel, x::AbstractVar; branchable=true)
@@ -115,6 +114,29 @@ function addToPrunedDomains!(prunedDomains::CPModification, x::Union{AbstractInt
     else
         prunedDomains[x.id] = pruned
     end
+end
+
+"""
+    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
+
+Update the `CPModification` by adding modified set values.
+
+# Arguments
+- `prunedDomains::CPModification`: the `CPModification` you want to update.
+- `x::IntSetVar`: the variable that had its values changed.
+- `modification::SetModification`: the modified values.
+"""
+function addToPrunedDomains!!(prunedDomains::CPModification, x::IntSetVar, modification::SetModification)
+    if isempty(modification.required) && isempty(modification.excluded)
+        return
+    end
+
+    if haskey(prunedDomains, x.id)
+        merge!(prunedDomains[x.id], modification)
+    else
+        prunedDomains[x.id] = modification
+    end
+    return
 end
 
 """

--- a/src/CP/variables/IntSetDomain.jl
+++ b/src/CP/variables/IntSetDomain.jl
@@ -64,7 +64,7 @@ end
 Exclude all possible not yet required values from the set domain.
 """
 function exclude_all!(dom::IntSetDomain)
-    excluded = dom.values[dom.indexes[dom.requiring_index.value:dom.excluding_index.value]]
+    excluded = dom.values[dom.requiring_index.value:dom.excluding_index.value] .+ (dom.min -1)
     setValue!(dom.excluding_index, dom.requiring_index.value - 1)
     return excluded
 end
@@ -75,7 +75,7 @@ end
 Require all possible not yet excluded values from the set domain.
 """
 function require_all!(dom::IntSetDomain)
-    required = dom.values[dom.indexes[dom.requiring_index.value:dom.excluding_index.value]]
+    required = dom.values[dom.requiring_index.value:dom.excluding_index.value] .+ (dom.min -1)
     setValue!(dom.requiring_index, dom.excluding_index.value + 1)
     return required
 end

--- a/src/CP/variables/IntSetDomain.jl
+++ b/src/CP/variables/IntSetDomain.jl
@@ -64,7 +64,9 @@ end
 Exclude all possible not yet required values from the set domain.
 """
 function exclude_all!(dom::IntSetDomain)
+    excluded = dom.values[dom.indexes[dom.requiring_index.value:dom.excluding_index.value]]
     setValue!(dom.excluding_index, dom.requiring_index.value - 1)
+    return excluded
 end
 
 """
@@ -73,7 +75,9 @@ end
 Require all possible not yet excluded values from the set domain.
 """
 function require_all!(dom::IntSetDomain)
+    required = dom.values[dom.indexes[dom.requiring_index.value:dom.excluding_index.value]]
     setValue!(dom.requiring_index, dom.excluding_index.value + 1)
+    return required
 end
 
 """

--- a/src/CP/variables/IntSetVar.jl
+++ b/src/CP/variables/IntSetVar.jl
@@ -23,6 +23,8 @@ function IntSetVar(min::Int, max::Int, id::String, trailer::Trailer)
     return IntSetVar(Constraint[], dom, id)
 end
 
+# TODO define SetModification
+
 """
     isbound(x::IntSetVar)
 

--- a/src/CP/variables/IntSetVar.jl
+++ b/src/CP/variables/IntSetVar.jl
@@ -23,7 +23,36 @@ function IntSetVar(min::Int, max::Int, id::String, trailer::Trailer)
     return IntSetVar(Constraint[], dom, id)
 end
 
-# TODO define SetModification
+"""
+    SetModification(; excluded::Array{Int}, required::Array{Int})
+
+Stock the two types of modification of a IntSetVar.
+"""
+struct SetModification
+    excluded::Array{Int}
+    required::Array{Int}
+    
+    function SetModification(;excluded::Union{Nothing,Array{Int}}=nothing, required::Union{Nothing,Array{Int}}=nothing)
+        if isnothing(excluded)
+            excluded = Int[]
+        end
+        if isnothing(required)
+            required = Int[]
+        end
+        return new(excluded, required)
+    end
+end
+
+"""
+    mergeSetModifications!(modif1, modif2)
+
+Add the modifications in `modif2` at the end of `modif1`
+"""
+function mergeSetModifications!(modif1::SetModification, modif2::SetModification)
+    append!(modif1.required, modif2.required)
+    append!(modif1.excluded, modif2.excluded)
+    return
+end
 
 """
     isbound(x::IntSetVar)

--- a/test/CP/CP.jl
+++ b/test/CP/CP.jl
@@ -5,6 +5,7 @@
     include("constraints/constraints.jl")
 
     include("core/fixPoint.jl")
+    include("core/cpModification.jl")
 
     include("core/search/strategies.jl")
 

--- a/test/CP/constraints/absolute.jl
+++ b/test/CP/constraints/absolute.jl
@@ -8,7 +8,7 @@
 
         @test constraint in x.onDomainChange
         @test constraint in y.onDomainChange
-        @test y.domain.min.value == 0
+        @test y.domain.min.value == -10
         @test y.domain.max.value == 10
         @test x.domain.min.value == -5
         @test x.domain.max.value == 5

--- a/test/CP/constraints/compacttable.jl
+++ b/test/CP/constraints/compacttable.jl
@@ -41,10 +41,15 @@
             1 2 3
         ]
         table = SeaPearl.cleanTable(vec, table)
-        @test !(1 in y.domain)
         support = SeaPearl.buildSupport(vec,table)
+        @test all([(i => j) in keys(support) for i = 1:3, j = 2:3])
+        @test (1 => 1) in keys(support)
         SeaPearl.cleanSupports!(support, vec)
-        @test !(1 in x.domain)
+        @test !((1 => 1) in keys(support))
+        @test !((1 => 3) in keys(support))
+        @test !((2 => 2) in keys(support))
+        @test !((3 => 1) in keys(support))
+        @test length(keys(support)) == 4
     end
     @testset "TableConstraint(variables::Vector{<:AbstractIntVar}, table::Matrix{Int}, supports::Dict{Pair{Int,Int},BitVector}, trailer)" begin
         trailer = SeaPearl.Trailer()

--- a/test/CP/constraints/setdiffsingleton.jl
+++ b/test/CP/constraints/setdiffsingleton.jl
@@ -43,7 +43,7 @@
         @test 3 in x.domain
         @test !(2 in x.domain)
         @test constraint.active.value
-        @test prunedDomains == SeaPearl.CPModification("x" => [2])
+        @test ("x" => [2]) in prunedDomains
 
 
         SeaPearl.assign!(x, 3)

--- a/test/CP/core/cpModification.jl
+++ b/test/CP/core/cpModification.jl
@@ -1,0 +1,89 @@
+@testset "CPModification" begin
+    
+    @testset "Integer variables" begin
+        trailer = SeaPearl.Trailer()
+        model = SeaPearl.CPModel(trailer)
+
+        x = SeaPearl.IntVar(-10, 10, "x", trailer)
+        y = SeaPearl.IntVar(-10, 10, "y", trailer)
+        z = SeaPearl.IntVar(-10, 10, "z", trailer)
+        a = SeaPearl.IntVar(-10, 10, "a", trailer)
+        b = SeaPearl.IntVar(1, 10, "b", trailer)
+        c = SeaPearl.IntVar(1, 10, "c", trailer)
+        SeaPearl.addVariable!.([model], [x, y, z, a, b, c])
+
+        c1 = SeaPearl.Absolute(a, x, trailer)
+        c2 = SeaPearl.AllDifferent([x, y, z], trailer)
+        c3 = SeaPearl.BinaryMaximumBC(y, a, z, trailer)
+        mat = fill(-8, (10, 10))
+        c4 = SeaPearl.Element2D(mat, b, c, a, trailer)
+        c5 = SeaPearl.Equal(b, c, trailer)
+        c6 = SeaPearl.GreaterOrEqualConstant(b, 5, trailer)
+        c7 = SeaPearl.NotEqual(z, a, trailer)
+        c8 = SeaPearl.SumGreaterThan([b, c], 18, trailer)
+        c9 = SeaPearl.SumLessThan([y, z], -18, trailer)
+        c10 = SeaPearl.SumToZero([z, b], trailer)
+        append!(model.constraints, [c1, c2, c3, c4, c5, c6, c7])
+
+        status, prunedDomains = SeaPearl.fixPoint!(model)
+
+        @test Set(prunedDomains["x"]) == setdiff(Set(-10:10), 8)
+        @test Set(prunedDomains["y"]) == setdiff(Set(-10:10), -8)
+        @test Set(prunedDomains["z"]) == setdiff(Set(-10:10), -10)
+        @test Set(prunedDomains["a"]) == setdiff(Set(-10:10), -8)
+        @test Set(prunedDomains["b"]) == setdiff(Set(1:10), 10)
+        @test Set(prunedDomains["c"]) == setdiff(Set(1:10), 10)
+    end
+
+    @testset "Boolean variables" begin
+        trailer = SeaPearl.Trailer()
+        model = SeaPearl.CPModel(trailer)
+
+        x = SeaPearl.IntVar(5, 10, "x", trailer)
+        y = SeaPearl.IntVar(8, 8, "y", trailer)
+        z = SeaPearl.IntSetVar(5, 10, "z", trailer)
+        a = SeaPearl.BoolVar("a", trailer)
+        b = SeaPearl.BoolVar("b", trailer)
+        c = SeaPearl.BoolVar("c", trailer)
+        SeaPearl.addVariable!.([model], [x, y, z, a, b, c]; branchable=false)
+
+        c1 = SeaPearl.BinaryOr(a, b, trailer)
+        c2 = SeaPearl.isBinaryOr(a, b, c, trailer)
+        c3 = SeaPearl.isLessOrEqual(c, x, y, trailer)
+        c4 = SeaPearl.ReifiedInSet(x, z, c, trailer)
+        c5 = SeaPearl.SetEqualConstant(z, Set(5:10), trailer)
+        append!(model.constraints, [c1, c2, c3, c4, c5])
+
+        status, prunedDomains = SeaPearl.fixPoint!(model)
+
+        @test prunedDomains["a"] == [false]
+        @test !("b" in keys(prunedDomains))
+        @test prunedDomains["c"] == [false]
+
+    end
+
+    @testset "Set variables" begin
+        trailer = SeaPearl.Trailer()
+        model = SeaPearl.CPModel(trailer)
+
+        x = SeaPearl.IntVar(6, 10, "x", trailer)
+        y = SeaPearl.IntSetVar(0, 10, "y", trailer)
+        z = SeaPearl.IntSetVar(5, 10, "z", trailer)
+        a = SeaPearl.BoolVar("a", trailer)
+        SeaPearl.addVariable!.([model], [x, y, z, a]; branchable=false)
+
+        c1 = SeaPearl.InSet(x, z, trailer)
+        c2 = SeaPearl.ReifiedInSet(x, z, a, trailer)
+        c3 = SeaPearl.SetDiffSingleton(y, z, x, trailer)
+        c4 = SeaPearl.SetEqualConstant(y, Set(7:10), trailer)
+        append!(model.constraints, [c1, c2, c3, c4])
+
+        status, prunedDomains = SeaPearl.fixPoint!(model)
+
+        @test Set(prunedDomains["y"].excluded) == Set(0:6)
+        @test Set(prunedDomains["y"].required) == Set(7:10)
+        @test Set(prunedDomains["z"].excluded) == Set(5)
+        @test Set(prunedDomains["z"].required) == Set(6:10)
+    end
+    
+end

--- a/test/CP/core/cpModification.jl
+++ b/test/CP/core/cpModification.jl
@@ -10,7 +10,8 @@
         a = SeaPearl.IntVar(-10, 10, "a", trailer)
         b = SeaPearl.IntVar(1, 10, "b", trailer)
         c = SeaPearl.IntVar(1, 10, "c", trailer)
-        SeaPearl.addVariable!.([model], [x, y, z, a, b, c])
+        d = SeaPearl.IntVar(-10, 10, "d", trailer)
+        SeaPearl.addVariable!.([model], [x, y, z, a, b, c, d])
 
         c1 = SeaPearl.Absolute(a, x, trailer)
         c2 = SeaPearl.AllDifferent([x, y, z], trailer)
@@ -23,7 +24,12 @@
         c8 = SeaPearl.SumGreaterThan([b, c], 18, trailer)
         c9 = SeaPearl.SumLessThan([y, z], -18, trailer)
         c10 = SeaPearl.SumToZero([z, b], trailer)
-        append!(model.constraints, [c1, c2, c3, c4, c5, c6, c7])
+        table = [
+            8 8 8 9 9 9 10 10 10;
+            1 2 3 5 6 7 8 9 10;
+        ]
+        c11 = SeaPearl.TableConstraint([c, d], table, trailer)
+        append!(model.constraints, [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11])
 
         status, prunedDomains = SeaPearl.fixPoint!(model)
 
@@ -33,6 +39,7 @@
         @test Set(prunedDomains["a"]) == setdiff(Set(-10:10), -8)
         @test Set(prunedDomains["b"]) == setdiff(Set(1:10), 10)
         @test Set(prunedDomains["c"]) == setdiff(Set(1:10), 10)
+        @test Set(prunedDomains["d"]) == setdiff(Set(-10:10), Set(8:10))
     end
 
     @testset "Boolean variables" begin


### PR DESCRIPTION
As proposed in #128, this PR brings new features to ensure the correctness of `prunedDomains` during each propagation. Thus te mains contributions are:

- the struct `SetModification` to make it possible to track changes in a set domain;
- a proof-read of every constraint to make sure that each domain change is followed by an `addToPrunedDomains!`;
- a testset dedicated to `CPModification`, to ensure that each constraint is updating it well.

During this work I encountered a few undetected bugs and made some minor changes:

- missing cases in `SetEqualConstant`;
- a few display error;
- prevent `Absolute` to prune values before the beginning of the execution, as this pruning is intractable for the other constraints.

If this PR is approved, we should now have a reliable `prunedDomains` variable, as long as all the new constraints follow a few guidelines. It would be great to write a few instructions about this for potential contributors.

Closes #128 