### PR TITLE
Feature/reward

### DIFF
--- a/src/CP/core/search/dfs.jl
+++ b/src/CP/core/search/dfs.jl
@@ -40,9 +40,8 @@ function expandDfs!(toCall::Stack{Function}, model::CPModel, variableHeuristic::
 
     # Variable selection
     x = variableHeuristic(model)
-
     # Value selection
-    v = valueSelection(DecisionPhase(), model, x, nothing)
+    v = valueSelection(DecisionPhase, model, x)
 
     #println("Value : ", v, " assigned to : ", x.id)
 

--- a/src/CP/core/search/ilds.jl
+++ b/src/CP/core/search/ilds.jl
@@ -56,7 +56,7 @@ function expandIlds!(toCall::Stack{Function}, discrepancy::Int64, previousdepth:
     # Variable selection
     x = variableHeuristic(model)
     # Value selection
-    v = valueSelection(DecisionPhase(), model, x, nothing)
+    v = valueSelection(DecisionPhase, model, x)
     if (discrepancy>=0)   
         push!(toCall, (model) -> (restoreState!(model.trailer); :BackTracking))
         push!(toCall, (model) -> (

--- a/src/CP/core/search/search.jl
+++ b/src/CP/core/search/search.jl
@@ -18,7 +18,7 @@ end
 function search!(model::CPModel, ::Type{Strategy}, variableHeuristic::AbstractVariableSelection, valueSelection::ValueSelection=BasicHeuristic(); out_solver::Bool=false) where Strategy <: SearchStrategy
 
     # create env and get first observation
-    valueSelection(InitializingPhase(), model, nothing, nothing)
+    valueSelection(InitializingPhase, model)
 
     toCall = Stack{Function}()
     # Starting at the root node with an empty stack
@@ -32,7 +32,7 @@ function search!(model::CPModel, ::Type{Strategy}, variableHeuristic::AbstractVa
 
         if currentStatus != :SavingState
             # set reward and metrics
-            valueSelection(StepPhase(), model, nothing, currentStatus)
+            valueSelection(StepPhase, model, currentStatus)
         end
 
         currentProcedure = pop!(toCall)
@@ -40,7 +40,7 @@ function search!(model::CPModel, ::Type{Strategy}, variableHeuristic::AbstractVa
     end
 
     # set final reward and last observation
-    valueSelection(EndingPhase(), model, nothing, nothing)
+    valueSelection(EndingPhase, model, currentStatus)
 
     if currentStatus == :NodeLimitStop || currentStatus == :SolutionLimitStop || (out_solver & (currentStatus in [:Infeasible, :FoundSolution]))
         return currentStatus

--- a/src/CP/valueselection/basicheuristic.jl
+++ b/src/CP/valueselection/basicheuristic.jl
@@ -10,6 +10,8 @@ To create one, the user just as to give it a function which map an `AbstractIntV
 """
 mutable struct BasicHeuristic <: ValueSelection
     selectValue::Function
+    search_metrics::Union{Nothing, SearchMetrics}
+
 end
 
 """
@@ -17,8 +19,8 @@ end
     
 Create the default `BasicHeuristic` that selects the maximum value of the domain
 """
-BasicHeuristic() = BasicHeuristic((x; cpmodel=nothing) -> maximum(x.domain))
-
+BasicHeuristic() = BasicHeuristic((x; cpmodel=nothing) -> maximum(x.domain), nothing)
+BasicHeuristic(selectValue::Function) = BasicHeuristic(selectValue, nothing)
 """
     (valueSelection::BasicHeuristic)(::LearningPhase, model, x, current_status)
 
@@ -26,9 +28,9 @@ Explains what the basicHeurstic should do at each step of the solving. This is u
 BasicHeuristic and LearnedHeuristic. In the case of the BasicHeuristic, it is only called in the DecisionPhase where the selectValue function is used
 to choose the value assigned. 
 """
-(valueSelection::BasicHeuristic)(::InitializingPhase, model::Union{Nothing, CPModel}=nothing, x::Union{Nothing, AbstractIntVar}=nothing, current_status::Union{Nothing, Symbol}=nothing) = nothing
-(valueSelection::BasicHeuristic)(::StepPhase, model::Union{Nothing, CPModel}=nothing, x::Union{Nothing, AbstractIntVar}=nothing, current_status::Union{Nothing, Symbol}=nothing) = nothing
-(valueSelection::BasicHeuristic)(::DecisionPhase, model::Union{Nothing, CPModel}=nothing, x::Union{Nothing, AbstractIntVar}=nothing, current_status::Union{Nothing, Symbol}=nothing) = valueSelection.selectValue(x; cpmodel=model)
-(valueSelection::BasicHeuristic)(::EndingPhase, model::Union{Nothing, CPModel}=nothing, x::Union{Nothing, AbstractIntVar}=nothing, current_status::Union{Nothing, Symbol}=nothing) = nothing
+(valueSelection::BasicHeuristic)(::Type{InitializingPhase}, model::Union{Nothing, CPModel}=nothing) = (valueSelectionsearch_metrics = SearchMetrics(model))
+(valueSelection::BasicHeuristic)(::Type{StepPhase}, model::Union{Nothing, CPModel}=nothing, current_status::Union{Nothing, Symbol}=nothing) = nothing
+(valueSelection::BasicHeuristic)(::Type{DecisionPhase}, model::Union{Nothing, CPModel}=nothing, x::Union{Nothing, AbstractIntVar}=nothing) = valueSelection.selectValue(x; cpmodel=model)
+(valueSelection::BasicHeuristic)(::Type{EndingPhase}, model::Union{Nothing, CPModel}=nothing, current_status::Union{Nothing, Symbol}=nothing) = nothing
 
 wears_mask(valueSelection::BasicHeuristic) = true

--- a/src/CP/valueselection/lh_utils.jl
+++ b/src/CP/valueselection/lh_utils.jl
@@ -120,15 +120,6 @@ RLBase.is_terminated(env::unmaskedCPEnv) = env.terminal
 RLBase.state(env::unmaskedCPEnv) = env.state
 RLBase.ActionStyle(::unmaskedCPEnv) = MINIMAL_ACTION_SET
 
-"""
-    set_metrics!(PHASE::T, lh::LearnedHeuristic, model::CPModel, symbol::Union{Nothing, Symbol}, x::Union{Nothing, AbstractIntVar}) where T <: LearningPhase 
-
-Call set_metrics!(::SearchMetrics, ...) on env.search_metrics to simplify synthax.
-Could also add it to basicheuristic !
-"""
-function set_metrics!(PHASE::T, lh::LearnedHeuristic, model::CPModel, symbol::Union{Nothing, Symbol}, x::Union{Nothing, AbstractIntVar}) where T <: LearningPhase
-    set_metrics!(PHASE, lh.search_metrics, model, symbol, x::Union{Nothing, AbstractIntVar})
-end
 
 wears_mask(valueSelection::LearnedHeuristic) = wears_mask(valueSelection.agent.policy.learner.approximator.model)
 

--- a/src/CP/valueselection/rewards/defaultreward.jl
+++ b/src/CP/valueselection/rewards/defaultreward.jl
@@ -14,11 +14,22 @@ DefaultReward(model::CPModel) = DefaultReward(0)
 
 Change the "current_reward" attribute of the LearnedHeuristic at the StepPhase.
 """
-function set_reward!(::StepPhase, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
+function set_reward!(::Type{StepPhase}, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
     SR <: AbstractStateRepresentation,
     A <: ActionOutput
 }
-    nothing
+    if symbol == :Infeasible  
+        lh.reward.value -= 10*model.statistics.numberOfNodes
+
+    elseif symbol == :FoundSolution
+        lh.reward.value -= 1
+
+    elseif symbol == :Feasible 
+        lh.reward.value -= 1
+
+    elseif symbol == :BackTracking
+        lh.reward.value -= 1
+    end
 end
 
 """
@@ -27,12 +38,12 @@ end
 Change the current reward at the DecisionPhase. This is called right before making the next decision, so you know you have the very last state before the new decision
 and every computation like fixPoints and backtracking has been done.
 """
-function set_reward!(::DecisionPhase, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel) where {
+function set_reward!(::Type{DecisionPhase}, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel) where {
     SR <: AbstractStateRepresentation,
     A <: ActionOutput
 }
     lh.reward.value += -1/40
-    nothing
+
 end
 
 
@@ -42,10 +53,10 @@ end
 Increment the current reward at the EndingPhase. Called when the search is finished by an optimality proof or by a limit in term of nodes or 
 in terms of number of solution. This is useful to add some general results to the reward like the number of ndoes visited during the episode for instance. 
 """
-function set_reward!(::EndingPhase, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
+function set_reward!(::Type{EndingPhase}, lh::LearnedHeuristic{SR, DefaultReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
     SR <: AbstractStateRepresentation, 
     A <: ActionOutput
 }
     lh.reward.value += 30/(model.statistics.numberOfNodes)
-    nothing
+
 end

--- a/src/CP/valueselection/rewards/tsptwreward.jl
+++ b/src/CP/valueselection/rewards/tsptwreward.jl
@@ -10,7 +10,6 @@ mutable struct TsptwReward <: AbstractReward
     positiver::Float32
     normalizer::Float32
     max_dist::Float32
-
 end
 
 """
@@ -44,11 +43,22 @@ set_reward!(::StepPhase, lh::LearnedHeuristic{SR, R::TsptwReward, A}, model::CPM
 
 Change the "current_reward" attribute of the LearnedHeuristic at the StepPhase.
 """
-function set_reward!(::StepPhase, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
+function set_reward!(::Type{StepPhase}, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
     SR <: AbstractStateRepresentation,
     A <: ActionOutput
-}
-    nothing
+}    
+    if symbol == :Infeasible  
+        lh.reward.value -= 10
+
+    elseif symbol == :FoundSolution
+        lh.reward.value -= 1
+
+    elseif symbol == :Feasible 
+        lh.reward.value -= 1
+
+    elseif symbol == :BackTracking
+        lh.reward.value -= 1
+    end
 end
 
 """
@@ -57,7 +67,7 @@ end
 Change the current reward at the DecisionPhase. This is called right before making the next decision, so you know you have the very last state before the new decision
 and every computation like fixPoints and backtracking has been done.
 """
-function set_reward!(::DecisionPhase, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel) where {
+function set_reward!(::Type{DecisionPhase}, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel) where {
     SR <: AbstractStateRepresentation,
     A <: ActionOutput
 }   
@@ -87,10 +97,9 @@ end
 Increment the current reward at the EndingPhase. Called when the search is finished by an optimality proof or by a limit in term of nodes or 
 in terms of number of solution. This is useful to add some general results to the reward like the number of ndoes visited during the episode for instance. 
 """
-function set_reward!(::EndingPhase, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
+function set_reward!(::Type{EndingPhase}, lh::LearnedHeuristic{SR, TsptwReward, A}, model::CPModel, symbol::Union{Nothing, Symbol}) where {
     SR <: AbstractStateRepresentation, 
     A <: ActionOutput
 }
     # lh.reward.value += 1.
-    nothing
 end

--- a/src/CP/valueselection/searchmetrics.jl
+++ b/src/CP/valueselection/searchmetrics.jl
@@ -69,7 +69,7 @@ end
 
 Set the search metrics thanks to informations from the CPModel and the current status during the StepPhase.
 """
-function set_metrics!(::StepPhase, search_metrics::SearchMetrics, model::CPModel, symbol::Union{Nothing, Symbol}, x::Union{Nothing, AbstractIntVar})
+function set_metrics!(::Type{StepPhase}, search_metrics::SearchMetrics, model::CPModel, symbol::Union{Nothing, Symbol} )
     search_metrics.total_steps += 1
     search_metrics.total_states += 1
     search_metrics.last_backtrack += 1
@@ -119,7 +119,7 @@ end
 
 Set the search metrics thanks to informations from the CPModel and the current status during the DecisionPhase
 """
-function set_metrics!(::DecisionPhase, search_metrics::SearchMetrics, model::CPModel, symbol::Union{Nothing, Symbol}, x::Union{Nothing, AbstractIntVar})
+function set_metrics!(::Type{DecisionPhase}, search_metrics::SearchMetrics, model::CPModel, x::Union{Nothing, AbstractIntVar})
     search_metrics.total_decisions += 1
     search_metrics.domains_product = search_metrics.new_domains_product
     search_metrics.new_domains_product = domains_cartesian_product(model)

--- a/src/CP/valueselection/valueselection.jl
+++ b/src/CP/valueselection/valueselection.jl
@@ -22,6 +22,7 @@ include("../../RL/RL.jl")
 
 abstract type ValueSelection end
 
+include("searchmetrics.jl")
 include("basicheuristic.jl")
 
 abstract type ActionOutput end

--- a/src/experiment/metrics/basicmetrics.jl
+++ b/src/experiment/metrics/basicmetrics.jl
@@ -238,7 +238,7 @@ end
 plot the relative scores ( compared to the optimal ) of the heuristic during the search for fixed instances along the training. This plot is 
 meaningful only if the metrics is one from the evaluator (ie. the instance remains the same one).
 """
-function plotRewardVariation(metrics::BasicMetrics{<:AbstractMetrics, LearnedHeuristic{SR,R,A}}; filename::String="") where {SR, R, A}
+function plotRewardVariation(metrics::BasicMetrics{<:AbstractTakeObjective, LearnedHeuristic{SR,R,A}}; filename::String="") where {SR, R, A}
     L = length(metrics.totalReward)
 
     p = plot(1:L, 

--- a/test/CP/valueselection/rewards/defaultreward.jl
+++ b/test/CP/valueselection/rewards/defaultreward.jl
@@ -8,7 +8,7 @@
         SeaPearl.update_with_cpmodel!(lh, model)
 
         lh.reward.value = 0
-        SeaPearl.set_reward!(SeaPearl.DecisionPhase(), lh, model)
+        SeaPearl.set_reward!(SeaPearl.DecisionPhase, lh, model)
         @test lh.reward.value == -0.025f0
     end
 
@@ -21,7 +21,7 @@
 
         lh.reward.value = 5
         model.statistics.numberOfNodes = 30
-        SeaPearl.set_reward!(SeaPearl.EndingPhase(), lh, model, nothing)
+        SeaPearl.set_reward!(SeaPearl.EndingPhase, lh, model, nothing)
         @test lh.reward.value == 6
     end
 end

--- a/test/CP/valueselection/rewards/rewards.jl
+++ b/test/CP/valueselection/rewards/rewards.jl
@@ -4,7 +4,7 @@ end
 
 TestReward(model::SeaPearl.CPModel) = TestReward(0)
 
-function SeaPearl.set_reward!(::SeaPearl.DecisionPhase, lh::SeaPearl.LearnedHeuristic{SR, TestReward, A}, model::SeaPearl.CPModel) where {
+function SeaPearl.set_reward!(::Type{SeaPearl.DecisionPhase}, lh::SeaPearl.LearnedHeuristic{SR, TestReward, A}, model::SeaPearl.CPModel) where {
     SR <: SeaPearl.AbstractStateRepresentation, 
     A <: SeaPearl.ActionOutput
 }
@@ -12,7 +12,7 @@ function SeaPearl.set_reward!(::SeaPearl.DecisionPhase, lh::SeaPearl.LearnedHeur
     nothing
 end
 
-function SeaPearl.set_reward!(::SeaPearl.EndingPhase, lh::SeaPearl.LearnedHeuristic{SR, TestReward, A}, model::SeaPearl.CPModel, symbol::Union{Nothing, Symbol}) where {
+function SeaPearl.set_reward!(::Type{SeaPearl.EndingPhase}, lh::SeaPearl.LearnedHeuristic{SR, TestReward, A}, model::SeaPearl.CPModel, symbol::Union{Nothing, Symbol}) where {
     SR <: SeaPearl.AbstractStateRepresentation, 
     A <: SeaPearl.ActionOutput
 }
@@ -26,6 +26,32 @@ end
     include("tsptwreward.jl")
 
     @testset "Custom reward" begin
+        @testset "set_reward(StepPhase)" begin
+            trailer = SeaPearl.Trailer()
+            model = SeaPearl.CPModel(trailer)
+    
+            lh = SeaPearl.LearnedHeuristic(agent)
+            SeaPearl.update_with_cpmodel!(lh, model)
+    
+            lh.reward.value = 0 
+            model.statistics.numberOfNodes = 1
+            SeaPearl.set_reward!(SeaPearl.StepPhase, lh, model,:Infeasible)
+            @test lh.reward.value == -10
+    
+            lh.reward.value = 0 
+            SeaPearl.set_reward!(SeaPearl.StepPhase, lh, model,:FoundSolution)
+            @test lh.reward.value == -1
+         
+            lh.reward.value = 0 
+            SeaPearl.set_reward!(SeaPearl.StepPhase, lh, model,:Feasible)
+            @test lh.reward.value == -1
+         
+            lh.reward.value = 0 
+            SeaPearl.set_reward!(SeaPearl.StepPhase, lh, model,:BackTracking)
+            @test lh.reward.value == -1
+    
+        end
+
         @testset "set_reward!(DecisionPhase)" begin
             trailer = SeaPearl.Trailer()
             model = SeaPearl.CPModel(trailer)
@@ -34,7 +60,7 @@ end
             SeaPearl.update_with_cpmodel!(lh, model)
 
             lh.reward.value = 0
-            SeaPearl.set_reward!(SeaPearl.DecisionPhase(), lh, model)
+            SeaPearl.set_reward!(SeaPearl.DecisionPhase, lh, model)
             @test lh.reward.value == 3
         end
 
@@ -46,7 +72,7 @@ end
             SeaPearl.update_with_cpmodel!(lh, model)
 
             lh.reward.value = 6
-            SeaPearl.set_reward!(SeaPearl.EndingPhase(), lh, model, nothing)
+            SeaPearl.set_reward!(SeaPearl.EndingPhase, lh, model, nothing)
             @test lh.reward.value == 1
         end
     end

--- a/test/CP/valueselection/rewards/tsptwreward.jl
+++ b/test/CP/valueselection/rewards/tsptwreward.jl
@@ -78,9 +78,9 @@ lh = SeaPearl.LearnedHeuristic{SeaPearl.TsptwStateRepresentation{SeaPearl.TsptwF
         println(model.variables["a_1"])
 
         x = first(values(SeaPearl.branchable_variables(model)))
-        SeaPearl.set_metrics!(SeaPearl.DecisionPhase(), lh, model, nothing, x)
+        SeaPearl.set_metrics!(SeaPearl.DecisionPhase, lh.search_metrics, model, x)
 
-        SeaPearl.set_reward!(SeaPearl.DecisionPhase(), lh, model)
+        SeaPearl.set_reward!(SeaPearl.DecisionPhase, lh, model)
         # @test lh.reward.value == 0.9887827f0
     end
 


### PR DESCRIPTION
This is my proposition to simplify the use of struct of subtype `LearningPhase `
The `Phase `argument called by `valueselection `heuristic is no longer a element of type `...Phase <: LearningPhase` but simply the Type `...Phase` itself. That saves an allocation at each step of the search. 

I also fixed a little bug on the `plotRewardVariation` function. 