### PR TITLE
fix CPModification update with View Variables

### DIFF
--- a/src/CP/CP.jl
+++ b/src/CP/CP.jl
@@ -4,15 +4,5 @@ abstract type Constraint end
 abstract type OnePropagationConstraint <: Constraint end
 
 include("variables/variables.jl")
-include("core/model.jl")
+include("core/core.jl")
 include("constraints/constraints.jl")
-
-include("core/fixPoint.jl")
-include("variableselection/variableselection.jl")
-
-include("core/search/strategies.jl")
-
-include("valueselection/valueselection.jl")
-
-include("core/search/search.jl")
-include("core/solver.jl")

--- a/src/CP/core/core.jl
+++ b/src/CP/core/core.jl
@@ -1,0 +1,13 @@
+include("model.jl")
+include("cpmodification.jl")
+include("fixPoint.jl")
+
+include("search/strategies.jl")
+
+include("../variableselection/variableselection.jl")
+include("../valueselection/valueselection.jl")
+
+include("search/search.jl")
+
+include("solver.jl")
+

--- a/src/CP/core/cpmodification.jl
+++ b/src/CP/core/cpmodification.jl
@@ -1,0 +1,87 @@
+const CPModification = Dict{String, Union{Array{Int}, Array{Bool}, SetModification}}
+
+"""
+    merge!(prunedDomains::CPModification, newPrunedDomains::CPModification)
+
+Merge `newPrunedDomains` into `prunedDomains`, concatenating the arrays if concerning the same variable.
+"""
+function merge!(prunedDomains::CPModification, newPrunedDomains::CPModification)
+    for k in keys(newPrunedDomains)
+        if haskey(prunedDomains, k)
+            prunedDomains[k] = vcat(prunedDomains[k], newPrunedDomains[k])
+        else
+            prunedDomains[k] = newPrunedDomains[k]
+        end
+    end
+end
+
+"""
+    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
+
+Update the `CPModification` by adding the pruned integers.
+
+# Arguments
+- `prunedDomains::CPModification`: the `CPModification` you want to update.
+- `x::IntVar`: the variable that had its domain pruned.
+- `pruned::Array{Int}`: the pruned integers.
+"""
+function addToPrunedDomains!(prunedDomains::CPModification, x::Union{IntVar, BoolVar}, pruned::Union{Array{Int}, Array{Bool}, BitArray})
+    if isempty(pruned)
+        return
+    end
+    if haskey(prunedDomains, x.id)
+        prunedDomains[x.id] = vcat(prunedDomains[x.id], Array(pruned))
+    else
+        prunedDomains[x.id] = Array(pruned)
+    end
+end
+
+"""
+    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
+
+Update the `CPModification` by adding the pruned integers.
+
+# Arguments
+- `prunedDomains::CPModification`: the `CPModification` you want to update.
+- `x::IntVar`: the variable that had its domain pruned.
+- `pruned::Array{Int}`: the pruned integers.
+"""
+function addToPrunedDomains!(prunedDomains::CPModification, x::Union{IntVarView, BoolVarView}, pruned::Union{Array{Int}, Array{Bool}, BitArray})
+    if isempty(pruned)
+        return
+    end
+
+    # Update the ViewVariable entry
+    if haskey(prunedDomains, x.id)
+        prunedDomains[x.id] = vcat(prunedDomains[x.id], Array(pruned))
+    else
+        prunedDomains[x.id] = Array(pruned)
+    end
+
+    # Update the ParentVariable entry
+    parentPruned = parentValue.([x], pruned)
+    addToPrunedDomains!(prunedDomains, x.x, parentPruned)
+end
+
+"""
+    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
+
+Update the `CPModification` by adding modified set values.
+
+# Arguments
+- `prunedDomains::CPModification`: the `CPModification` you want to update.
+- `x::IntSetVar`: the variable that had its values changed.
+- `modification::SetModification`: the modified values.
+"""
+function addToPrunedDomains!(prunedDomains::CPModification, x::IntSetVar, modification::SetModification)
+    if isempty(modification.required) && isempty(modification.excluded)
+        return
+    end
+
+    if haskey(prunedDomains, x.id)
+        mergeSetModifications!(prunedDomains[x.id], modification)
+    else
+        prunedDomains[x.id] = modification
+    end
+    return
+end

--- a/src/CP/core/model.jl
+++ b/src/CP/core/model.jl
@@ -41,8 +41,6 @@ end
 
 CPModel() = CPModel(Trailer())
 
-const CPModification = Dict{String, Union{Array{Int}, Array{Bool}, SetModification}}
-
 """
     addVariable!(model::CPModel, x::AbstractVar; branchable=true)
 
@@ -84,65 +82,6 @@ function branchable_variables(model::CPModel)
         end
     end
     to_return
-end
-
-"""
-    merge!(prunedDomains::CPModification, newPrunedDomains::CPModification)
-
-Merge `newPrunedDomains` into `prunedDomains`, concatenating the arrays if concerning the same variable.
-"""
-function merge!(prunedDomains::CPModification, newPrunedDomains::CPModification)
-    for k in keys(newPrunedDomains)
-        if haskey(prunedDomains, k)
-            prunedDomains[k] = vcat(prunedDomains[k], newPrunedDomains[k])
-        else
-            prunedDomains[k] = newPrunedDomains[k]
-        end
-    end
-end
-
-"""
-    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
-
-Update the `CPModification` by adding the pruned integers.
-
-# Arguments
-- `prunedDomains::CPModification`: the `CPModification` you want to update.
-- `x::IntVar`: the variable that had its domain pruned.
-- `pruned::Array{Int}`: the pruned integers.
-"""
-function addToPrunedDomains!(prunedDomains::CPModification, x::Union{AbstractIntVar, AbstractBoolVar}, pruned::Union{Array{Int}, Array{Bool}, BitArray})
-    if isempty(pruned)
-        return
-    end
-    if haskey(prunedDomains, x.id)
-        prunedDomains[x.id] = vcat(prunedDomains[x.id], Array(pruned))
-    else
-        prunedDomains[x.id] = Array(pruned)
-    end
-end
-
-"""
-    addToPrunedDomains!(prunedDomains::CPModification, x::IntVar, pruned::Array{Int})
-
-Update the `CPModification` by adding modified set values.
-
-# Arguments
-- `prunedDomains::CPModification`: the `CPModification` you want to update.
-- `x::IntSetVar`: the variable that had its values changed.
-- `modification::SetModification`: the modified values.
-"""
-function addToPrunedDomains!(prunedDomains::CPModification, x::IntSetVar, modification::SetModification)
-    if isempty(modification.required) && isempty(modification.excluded)
-        return
-    end
-
-    if haskey(prunedDomains, x.id)
-        mergeSetModifications!(prunedDomains[x.id], modification)
-    else
-        prunedDomains[x.id] = modification
-    end
-    return
 end
 
 """

--- a/src/CP/core/search/search.jl
+++ b/src/CP/core/search/search.jl
@@ -1,7 +1,6 @@
 
 include("dfs.jl")
 include("ilds.jl")
-include("strategies.jl")
 
 """
     search!(model::CPModel, ::Type{Strategy}, variableHeuristic, valueSelection::ValueSelection=BasicHeuristic())

--- a/src/CP/variables/BoolVarView.jl
+++ b/src/CP/variables/BoolVarView.jl
@@ -87,3 +87,5 @@ function Base.iterate(dom::BoolDomainViewNot, state=1)
     value, newState = returned
     return !value, newState
 end
+
+parentValue(::BoolVarViewNot, v::Bool) = ! v

--- a/src/CP/variables/IntVarView.jl
+++ b/src/CP/variables/IntVarView.jl
@@ -261,3 +261,7 @@ function updateMinFromRemovedVal!(dom::IntDomainViewOffset, v::Int)
         updateMinFromRemovedVal!(dom.orig, v - dom.c)
     end
 end
+
+parentValue(y::IntVarViewMul, v::Int) = v ÷ y.a
+parentValue(y::IntVarViewOffset, v::Int) = v - y.c
+parentValue(::IntVarViewOpposite, v::Int) = - v

--- a/test/CP/constraints/equal.jl
+++ b/test/CP/constraints/equal.jl
@@ -25,7 +25,10 @@
         @test 6 in ax.domain
         @test !(9 in ax.domain)
         @test !(10 in ax.domain)
-        @test prunedDomains == SeaPearl.CPModification("3x" => [9, 12, 15, 18])
+        @test prunedDomains == SeaPearl.CPModification(
+            "3x" => [9, 12, 15, 18],
+            "x"  => [3, 4, 5, 6]
+        )
 
 
         cons2 = SeaPearl.EqualConstant(ax, 9, trailer)

--- a/test/CP/constraints/notequal.jl
+++ b/test/CP/constraints/notequal.jl
@@ -113,7 +113,10 @@
         @test SeaPearl.propagate!(constraint2, toPropagate, prunedDomains)
         @test constraint in toPropagate
         @test !(constraint2 in toPropagate)
-        @test prunedDomains == SeaPearl.CPModification("-y" => [5])
+        @test prunedDomains == SeaPearl.CPModification(
+            "-y" => [5],
+            "y"  => [-5]
+        )
         @test length(y.domain) == 3
 
         #Unfeasible test

--- a/test/CP/constraints/sumtozero.jl
+++ b/test/CP/constraints/sumtozero.jl
@@ -38,7 +38,10 @@
         @test 8 in y.domain
         @test !(7 in y.domain)
         @test !(13 in ax.domain)
-        @test prunedDomains == SeaPearl.CPModification("-y" => [-5, -6, -7, -13, -14, -15])
+        @test prunedDomains == SeaPearl.CPModification(
+            "-y" => [-5, -6, -7, -13, -14, -15],
+            "y"  => [5, 6, 7, 13, 14, 15]
+        )
 
 
         cons2 = SeaPearl.EqualConstant(y, 15, trailer)


### PR DESCRIPTION
As observed almost a year ago in #55 , `CPModification` isn't updated correctly with `IntVarView` and `BoolVarView`.

I propose a fix by providing a new definition of `addToPrunedDomains` for VariableViews. After creating/updating the entry corresponding to the view, it recursively call the function for the parent variable until a root variable is found.

Fixes #55.