### PR TITLE
Failure based search, a first step towards an intelligent variable selection heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ model = SeaPearl.CPModel(trailer)
 SeaPearl.addVariable!(...)
 
 #add constraints : 
-push!(model.constraints, SeaPearl.AbstractConstraint(...))
+SeaPearl.addConstraint!(model, SeaPearl.AbstractConstraint(...))
 
 #add optionnal objective function : 
 SeaPearl.addObjective!(model, ObjectiveVar)

--- a/src/CP/constraints/disjunctive.jl
+++ b/src/CP/constraints/disjunctive.jl
@@ -154,3 +154,5 @@ function propagate!(constraint::Disjunctive, toPropagate::Set{Constraint}, prune
 
     return true
 end
+
+variablesArray(constraint::Disjunctive) = map(x -> x.earliestStartingTime, constraint.tasks)

--- a/src/CP/core/fixPoint.jl
+++ b/src/CP/core/fixPoint.jl
@@ -39,6 +39,7 @@ function fixPoint!(model::CPModel, new_constraints::Union{Array{Constraint}, Not
     while !isempty(toPropagate)
         constraint = pop!(toPropagate)
         if !propagate!(constraint, toPropagate, prunedDomains)
+            triggerInfeasible!(constraint, model)   
             return false, prunedDomains
         end
     end

--- a/src/CP/core/model.jl
+++ b/src/CP/core/model.jl
@@ -3,6 +3,7 @@ const Solution = Dict{String, Union{Int, Bool, Set{Int}}}
 
 #TODO add documentation for BeforeRestart
 mutable struct Statistics
+    infeasibleStatusPerVariable             ::Dict{String, Int}
     numberOfNodes                           ::Int
     numberOfSolutions                       ::Int
     numberOfInfeasibleSolutions             ::Int
@@ -41,7 +42,7 @@ mutable struct CPModel
     statistics              ::Statistics
     limit                   ::Limit
     adhocInfo               ::Any
-    CPModel(trailer) = new(Dict{String, AbstractVar}(), Dict{String, Bool}(), Constraint[], trailer, nothing, nothing, Statistics(0, 0, 0, 0, 0, 0, Solution[],Int[],nothing), Limit(nothing, nothing))
+    CPModel(trailer) = new(Dict{String, AbstractVar}(), Dict{String, Bool}(), Constraint[], trailer, nothing, nothing, Statistics(Dict{String, Int}(), 0, 0, 0, 0, 0, 0, Solution[],Int[],nothing), Limit(nothing, nothing))
 end
 
 CPModel() = CPModel(Trailer())
@@ -57,7 +58,8 @@ function addVariable!(model::CPModel, x::AbstractVar; branchable=true)
     @assert !haskey(model.variables, x.id) "The id of the variable must be unique"
 
     @assert !branchable || typeof(x) <: Union{AbstractIntVar, AbstractBoolVar} "You can only branch on Boolean and Integer variables"
-
+    
+    model.statistics.infeasibleStatusPerVariable[id(x)]=0
     model.branchable[x.id] = branchable
     model.variables[x.id] = x
 end
@@ -66,6 +68,15 @@ function addObjective!(model::CPModel, objective::AbstractVar)
     model.objective = objective
     model.statistics.objectives = Int[]  #initialisation of the Array that will contain the score of every solution
 end
+
+function addConstraint!(model::CPModel,constraint::Constraint)
+    push!(model.constraints,constraint)
+    for var in variablesArray(constraint)
+        @assert !haskey(model.statistics.infeasibleStatusPerVariable, id(var)) "You forget to add the variable $(id(var)) to the model"
+        model.statistics.infeasibleStatusPerVariable[id(var)]+=1
+    end   
+end
+
 
 """
     function is_branchable(model::CPModel, x::AbstractVar)
@@ -128,6 +139,19 @@ function triggerFoundSolution!(model::CPModel)
         tightenObjective!(model)
     end
 end
+"""
+    triggerInfeasible!(constraint::Constraint, model::CPModel)
+
+this function increments by one the statistic infeasibleStatusPerVariable for each variable involved in the constraint _constraint_. infeasibleStatusPerVariable
+keeps in track for each variable the number of times the variable was involved in a constraint that led to an infeasible state during a fixpoint. This statistic 
+is used by the failure-based variable selection heuristic. 
+"""
+function triggerInfeasible!(constraint::Constraint, model::CPModel)
+    for var in variablesArray(constraint)
+        model.statistics.infeasibleStatusPerVariable[id(var)]=length(getOnDomainChange(var))
+    end
+end
+
 
 """
     tightenObjective!(model::CPModel)
@@ -162,6 +186,7 @@ function Base.isempty(model::CPModel)::Bool
         && isnothing(model.objectiveBound)
         && isempty(model.statistics.solutions)
         && isempty(model.statistics.nodevisitedpersolution)
+        && isempty(model.statistics.infeasibleStatusPerVariable)
         && isnothing(model.statistics.objectives)
         && model.statistics.numberOfNodes == 0
         && model.statistics.numberOfSolutions == 0
@@ -188,6 +213,7 @@ function Base.empty!(model::CPModel)
     model.objectiveBound = nothing
     empty!(model.statistics.solutions)
     empty!(model.statistics.nodevisitedpersolution)
+    empty!(model.statistics.infeasibleStatusPerVariable)
     model.statistics.objectives = nothing
     model.statistics.numberOfNodes = 0
     model.statistics.numberOfSolutions = 0
@@ -212,6 +238,7 @@ function reset_model!(model::CPModel)
     model.objectiveBound = nothing
     empty!(model.statistics.solutions)
     empty!(model.statistics.nodevisitedpersolution)
+    empty!(model.statistics.infeasibleStatusPerVariable)
     if !isnothing(model.objective)
         @assert !isnothing(model.statistics.objectives)   "did you used SeaPearl.addObjective! to declare your objective function ?"
         empty!(model.statistics.objectives)
@@ -266,3 +293,4 @@ function nb_boundvariables(model::CPModel)
     end
     return nb
 end
+

--- a/src/CP/variables/BoolVarView.jl
+++ b/src/CP/variables/BoolVarView.jl
@@ -43,6 +43,8 @@ Return the size of `dom`.
 """
 Base.length(dom::BoolDomainView) = length(dom.orig)
 
+id(dom::BoolVarView) = id(dom.x)
+
 """
     Base.in(value::Bool, dom::BoolDomainViewNot)
 

--- a/src/CP/variables/BoolVarView.jl
+++ b/src/CP/variables/BoolVarView.jl
@@ -43,8 +43,6 @@ Return the size of `dom`.
 """
 Base.length(dom::BoolDomainView) = length(dom.orig)
 
-id(dom::BoolVarView) = id(dom.x)
-
 """
     Base.in(value::Bool, dom::BoolDomainViewNot)
 

--- a/src/CP/variables/IntVarView.jl
+++ b/src/CP/variables/IntVarView.jl
@@ -84,7 +84,6 @@ Return the "true" variable behind `x`.
 """
 rootVariable(x::IntVarView) = rootVariable(x.x)
 
-id(x::IntVarView) = id(x.x)
 """
     length(dom::IntDomainView)
 

--- a/src/CP/variables/IntVarView.jl
+++ b/src/CP/variables/IntVarView.jl
@@ -84,6 +84,7 @@ Return the "true" variable behind `x`.
 """
 rootVariable(x::IntVarView) = rootVariable(x.x)
 
+id(x::IntVarView) = id(x.x)
 """
     length(dom::IntDomainView)
 

--- a/src/CP/variables/variables.jl
+++ b/src/CP/variables/variables.jl
@@ -24,6 +24,7 @@ Return the `string` identifier of `x`. Every variable must be assigned a unique 
 will be used as a key to identify the variable in the `CPModel` object.
 """
 id(x::AbstractVar) = x.id
+parentId(x::AbstractVar) = rootVariable(x).id
 
 include("IntDomain.jl")
 include("IntVar.jl")

--- a/src/CP/variableselection/failureBased.jl
+++ b/src/CP/variableselection/failureBased.jl
@@ -1,0 +1,30 @@
+struct FailureBasedVariableSelection{TakeObjective} <: AbstractVariableSelection{TakeObjective} end
+
+FailureBasedVariableSelection(;take_objective=true) = FailureBasedVariableSelection{take_objective}()
+
+function (::FailureBasedVariableSelection{false})(cpmodel::CPModel)
+    selectedVar = nothing
+    minSize = Inf
+    for (k, x) in branchable_variables(cpmodel)
+        if x !== cpmodel.objective && !isbound(x) && length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)] <= minSize
+            selectedVar = x
+            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)]
+        end
+    end
+    if isnothing(selectedVar) && !isbound(cpmodel.objective)
+        return cpmodel.objective
+    end
+    return selectedVar
+end
+
+function (::FailureBasedVariableSelection{true})(cpmodel::CPModel)
+    selectedVar = nothing
+    minSize = Inf
+    for (k, x) in branchable_variables(cpmodel)
+        if !isbound(x) && length(x.domain)/ cpmodel.statistics.infeasibleStatusPerVariable[id(x)] <= minSize
+            selectedVar = x
+            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)]
+        end
+    end
+    return selectedVar
+end

--- a/src/CP/variableselection/failureBased.jl
+++ b/src/CP/variableselection/failureBased.jl
@@ -6,9 +6,9 @@ function (::FailureBasedVariableSelection{false})(cpmodel::CPModel)
     selectedVar = nothing
     minSize = Inf
     for (k, x) in branchable_variables(cpmodel)
-        if x !== cpmodel.objective && !isbound(x) && length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)] <= minSize
+        if x !== cpmodel.objective && !isbound(x) && length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[parentId(x)] <= minSize
             selectedVar = x
-            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)]
+            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[parentId(x)]
         end
     end
     if isnothing(selectedVar) && !isbound(cpmodel.objective)
@@ -21,9 +21,9 @@ function (::FailureBasedVariableSelection{true})(cpmodel::CPModel)
     selectedVar = nothing
     minSize = Inf
     for (k, x) in branchable_variables(cpmodel)
-        if !isbound(x) && length(x.domain)/ cpmodel.statistics.infeasibleStatusPerVariable[id(x)] <= minSize
+        if !isbound(x) && length(x.domain)/ cpmodel.statistics.infeasibleStatusPerVariable[parentId(x)] <= minSize
             selectedVar = x
-            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[id(x)]
+            minSize = length(x.domain) / cpmodel.statistics.infeasibleStatusPerVariable[parentId(x)]
         end
     end
     return selectedVar

--- a/src/CP/variableselection/variableselection.jl
+++ b/src/CP/variableselection/variableselection.jl
@@ -8,3 +8,4 @@ abstract type AbstractVariableSelection{TakeObjective} end
 
 include("mindomain.jl")
 include("random.jl")
+include("failureBased.jl")

--- a/src/datagen/coloring.jl
+++ b/src/datagen/coloring.jl
@@ -48,7 +48,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::LegacyGraphColoringGenerato
     for i in 1:length(connexions)
         neighbors = Distributions.sample([j for j in 1:length(connexions) if j != i && connexions[i] > 0], connexions[i], replace=false)
         for j in neighbors
-            push!(cpmodel.constraints, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
+            SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
         end
     end
 
@@ -56,7 +56,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::LegacyGraphColoringGenerato
     numberOfColors = SeaPearl.IntVar(1, nb_nodes, "numberOfColors", cpmodel.trailer)
     SeaPearl.addVariable!(cpmodel, numberOfColors)
     for var in x
-        push!(cpmodel.constraints, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
     end
     cpmodel.objective = numberOfColors
 
@@ -104,7 +104,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::HomogenousGraphColoringGene
     for i in 1:n
         for j in 1:n
             if i != j && rand() <= p
-                push!(cpmodel.constraints, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
+                SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
             end
         end
     end
@@ -113,7 +113,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::HomogenousGraphColoringGene
     numberOfColors = SeaPearl.IntVar(1, n, "numberOfColors", cpmodel.trailer)
     SeaPearl.addVariable!(cpmodel, numberOfColors)
     for var in x
-        push!(cpmodel.constraints, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
     end
     SeaPearl.addObjective!(cpmodel,numberOfColors)
     nothing
@@ -174,7 +174,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::ClusterizedGraphColoringGen
     for i in 1:n
         for j in 1:n
             if i != j && assigned_colors[i] != assigned_colors[j] && rand() <= p
-                push!(cpmodel.constraints, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
+                SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x[i], x[j], cpmodel.trailer))
             end
         end
     end
@@ -183,7 +183,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::ClusterizedGraphColoringGen
     numberOfColors = SeaPearl.IntVar(1, n, "numberOfColors", cpmodel.trailer)
     SeaPearl.addVariable!(cpmodel, numberOfColors)
     for var in x
-        push!(cpmodel.constraints, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.LessOrEqual(var, numberOfColors, cpmodel.trailer))
     end
     SeaPearl.addObjective!(cpmodel,numberOfColors)
     nothing

--- a/src/datagen/eternity2.jl
+++ b/src/datagen/eternity2.jl
@@ -108,12 +108,12 @@ function fill_with_generator!(cpmodel::CPModel, gen::Eternity2Generator; seed=12
         r[i,j] = src_v[i,j+1]
 
         vars = SeaPearl.AbstractIntVar[id[i,j], u[i,j], r[i,j],d[i,j], l[i,j], orientation[i,j]]
-        push!(cpmodel.constraints, SeaPearl.TableConstraint(vars, table, cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.TableConstraint(vars, table, cpmodel.trailer))
 
-        if (j==m) push!(cpmodel.constraints, SeaPearl.EqualConstant(r[i,j], 0, cpmodel.trailer)) end
-        if (j==1) push!(cpmodel.constraints, SeaPearl.EqualConstant(l[i,j], 0, cpmodel.trailer)) end
-        if (i==1) push!(cpmodel.constraints, SeaPearl.EqualConstant(u[i,j], 0, cpmodel.trailer)) end
-        if (i==n) push!(cpmodel.constraints, SeaPearl.EqualConstant(d[i,j], 0, cpmodel.trailer)) end
+        if (j==m) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(r[i,j], 0, cpmodel.trailer)) end
+        if (j==1) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(l[i,j], 0, cpmodel.trailer)) end
+        if (i==1) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(u[i,j], 0, cpmodel.trailer)) end
+        if (i==n) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(d[i,j], 0, cpmodel.trailer)) end
     end
 
     return nothing
@@ -206,24 +206,24 @@ function fill_with_generator!(cpmodel::CPModel, gen::Eternity2Generator; seed=12
         r[i,j] = src_v[i,j+1]
 
         vars = SeaPearl.AbstractIntVar[id[i,j], u[i,j], r[i,j],d[i,j], l[i,j]]
-        push!(cpmodel.constraints, SeaPearl.TableConstraint(vars, table, cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.TableConstraint(vars, table, cpmodel.trailer))
 
-        if (j==m) push!(cpmodel.constraints, SeaPearl.EqualConstant(r[i,j], 0, cpmodel.trailer)) end
-        if (j==1) push!(cpmodel.constraints, SeaPearl.EqualConstant(l[i,j], 0, cpmodel.trailer)) end
-        if (i==1) push!(cpmodel.constraints, SeaPearl.EqualConstant(u[i,j], 0, cpmodel.trailer)) end
-        if (i==n) push!(cpmodel.constraints, SeaPearl.EqualConstant(d[i,j], 0, cpmodel.trailer)) end
+        if (j==m) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(r[i,j], 0, cpmodel.trailer)) end
+        if (j==1) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(l[i,j], 0, cpmodel.trailer)) end
+        if (i==1) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(u[i,j], 0, cpmodel.trailer)) end
+        if (i==n) SeaPearl.addConstraint!(cpmodel, SeaPearl.EqualConstant(d[i,j], 0, cpmodel.trailer)) end
     end
 
     #breaking some symmetries
 
     #if count(==(2),count(==(0),pieces,dims=2))==4
         #index = findfirst(==(2),vec(count(==(0),pieces,dims=2)))
-        #push!(model.constraints,SeaPearl.EqualConstant(id[1,1], index, trailer))
+        #SeaPearl.addConstraint!(model,SeaPearl.EqualConstant(id[1,1], index, trailer))
         #SeaPearl.assign!(id[1,1].domain, index)
     #end
 
 
-    push!(cpmodel.constraints, SeaPearl.AllDifferent(id, cpmodel.trailer))
+    SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(id, cpmodel.trailer))
     return nothing
 
 end

--- a/src/datagen/knapsack.jl
+++ b/src/datagen/knapsack.jl
@@ -64,11 +64,11 @@ function fill_with_generator!(cpmodel::CPModel, gen::KnapsackGenerator; seed=not
     SeaPearl.addVariable!(cpmodel, minusTotalWeight;branchable=false)
     push!(varsWeight, minusTotalWeight)
     weightEquality = SeaPearl.SumToZero(varsWeight, cpmodel.trailer)
-    push!(cpmodel.constraints, weightEquality)
+    SeaPearl.addConstraint!(cpmodel, weightEquality)
 
     # Making sure it is below the capacity
     weightConstraint = SeaPearl.LessOrEqualConstant(totalWeight, capacity, cpmodel.trailer)
-    push!(cpmodel.constraints, weightConstraint)
+    SeaPearl.addConstraint!(cpmodel, weightConstraint)
 
     ### Objective ### minimize: -sum(v[i]*x_a[i])
 
@@ -84,7 +84,7 @@ function fill_with_generator!(cpmodel::CPModel, gen::KnapsackGenerator; seed=not
     SeaPearl.addVariable!(cpmodel, totalValue;branchable=false)
     push!(varsValue, totalValue)
     valueEquality = SeaPearl.SumToZero(varsValue, cpmodel.trailer)
-    push!(cpmodel.constraints, valueEquality)
+    SeaPearl.addConstraint!(cpmodel, valueEquality)
 
     # Setting it as the objective
     SeaPearl.addObjective!(cpmodel,totalValue)

--- a/src/datagen/latin.jl
+++ b/src/datagen/latin.jl
@@ -61,12 +61,12 @@ function fill_with_generator!(cpmodel::CPModel, gen::LatinGenerator; seed=nothin
         for j in 1:N
             puzzle[i,j] = SeaPearl.IntVar(1, N, "puzzle_"*string(i)*","*string(j), cpmodel.trailer)
             SeaPearl.addVariable!(cpmodel, puzzle[i,j]; branchable=true)
-            if B[i,j]>0 push!(cpmodel.constraints,SeaPearl.EqualConstant(puzzle[i,j], B[i,j], cpmodel.trailer)) end
+            if B[i,j]>0 SeaPearl.addConstraint!(cpmodel,SeaPearl.EqualConstant(puzzle[i,j], B[i,j], cpmodel.trailer)) end
         end
     end
     for i in 1:N
-        push!(cpmodel.constraints, SeaPearl.AllDifferent(puzzle[i,:], cpmodel.trailer))
-        push!(cpmodel.constraints, SeaPearl.AllDifferent(puzzle[:,i], cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(puzzle[i,:], cpmodel.trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(puzzle[:,i], cpmodel.trailer))
     end
     return nothing
 end

--- a/src/datagen/nqueens.jl
+++ b/src/datagen/nqueens.jl
@@ -47,9 +47,9 @@ function fill_with_generator!(cpmodel::CPModel, gen::NQueensGenerator; seed=noth
         #SeaPearl.addVariable!(model, rows_minus[i]; branchable=false)
     end
 
-    push!(cpmodel.constraints, SeaPearl.AllDifferent(rows, cpmodel.trailer))
-    push!(cpmodel.constraints, SeaPearl.AllDifferent(rows_plus, cpmodel.trailer))
-    push!(cpmodel.constraints, SeaPearl.AllDifferent(rows_minus, cpmodel.trailer))
+    SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(rows, cpmodel.trailer))
+    SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(rows_plus, cpmodel.trailer))
+    SeaPearl.addConstraint!(cpmodel, SeaPearl.AllDifferent(rows_minus, cpmodel.trailer))
     return nothing
     #return model
 end

--- a/test/CP/constraints/alldifferent.jl
+++ b/test/CP/constraints/alldifferent.jl
@@ -264,4 +264,15 @@
         @test status == :Optimal
         @test length(model.statistics.solutions) == 40
     end
+
+    @testset "variablesArray()" begin 
+        trailer = SeaPearl.Trailer()
+        x = SeaPearl.IntVar(1, 3, "x", trailer)
+        y = SeaPearl.IntVar(2, 3, "y", trailer)
+        z = SeaPearl.IntVar(2, 3, "Z", trailer)
+        vec = Vector{SeaPearl.IntVar}([x, y, z])
+
+        constraint = SeaPearl.AllDifferent(vec, trailer)
+        @test length(SeaPearl.variablesArray(constraint)) == 3
+    end
 end

--- a/test/CP/constraints/alldifferent.jl
+++ b/test/CP/constraints/alldifferent.jl
@@ -221,9 +221,9 @@
             #SeaPearl.addVariable!(model, rows_minus[i]; branchable=false)
         end
 
-        push!(model.constraints, SeaPearl.AllDifferent(rows, trailer))
-        push!(model.constraints, SeaPearl.AllDifferent(rows_plus, trailer))
-        push!(model.constraints, SeaPearl.AllDifferent(rows_minus, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows_plus, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows_minus, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         status = SeaPearl.solve!(model; variableHeuristic=variableSelection)
@@ -254,9 +254,9 @@
             #SeaPearl.addVariable!(model, rows_minus[i]; branchable=false)
         end
 
-        push!(model.constraints, SeaPearl.AllDifferent(rows, trailer))
-        push!(model.constraints, SeaPearl.AllDifferent(rows_plus, trailer))
-        push!(model.constraints, SeaPearl.AllDifferent(rows_minus, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows_plus, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.AllDifferent(rows_minus, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         status = SeaPearl.solve!(model; variableHeuristic=variableSelection)

--- a/test/CP/constraints/compacttable.jl
+++ b/test/CP/constraints/compacttable.jl
@@ -169,8 +169,8 @@
         constraint1 = SeaPearl.TableConstraint([x, y, z, a], table1, trailer)
         constraint2 = SeaPearl.TableConstraint([a, b, c], table2, trailer)
 
-        push!(model.constraints, constraint1)
-        push!(model.constraints, constraint2)
+        SeaPearl.addConstraint!(model, constraint1)
+        SeaPearl.addConstraint!(model, constraint2)
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         SeaPearl.solve!(model; variableHeuristic=variableSelection)

--- a/test/CP/constraints/disjunctive.jl
+++ b/test/CP/constraints/disjunctive.jl
@@ -235,7 +235,7 @@
 
         tasks = Vector{SeaPearl.IntVar}([task1, task2, task3])
         processing_time = [p1, p2, p3]
-        push!(model.constraints,SeaPearl.Disjunctive(tasks, processing_time, trailer))
+        SeaPearl.addConstraint!(model,SeaPearl.Disjunctive(tasks, processing_time, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         status = @time SeaPearl.solve!(model; variableHeuristic=variableSelection)
@@ -257,7 +257,7 @@
         p3 = 3
         tasks = Vector{SeaPearl.IntVar}([task1, task2, task3])
         processing_time = [p1, p2, p3]
-        push!(model.constraints,SeaPearl.Disjunctive(tasks, processing_time, trailer))
+        SeaPearl.addConstraint!(model,SeaPearl.Disjunctive(tasks, processing_time, trailer))
         SeaPearl.addVariable!(model, task1)
         SeaPearl.addVariable!(model, task2)
         SeaPearl.addVariable!(model, task3)
@@ -343,7 +343,7 @@
         p3 = 3
         tasks = Vector{SeaPearl.IntVar}([task1, task2, task3])
         processing_time = [p1, p2, p3]
-        push!(model.constraints,SeaPearl.Disjunctive(tasks, processing_time, trailer))
+        SeaPearl.addConstraint!(model,SeaPearl.Disjunctive(tasks, processing_time, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         status = @time SeaPearl.solve!(model; variableHeuristic=variableSelection)
@@ -375,7 +375,7 @@
         p3 = 3
         tasks = Vector{SeaPearl.IntVar}([task1, task2, task3])
         processing_time = [p1, p2, p3]
-        push!(model.constraints,SeaPearl.Disjunctive(tasks, processing_time, trailer))
+        SeaPearl.addConstraint!(model,SeaPearl.Disjunctive(tasks, processing_time, trailer))
 
         variableSelection = SeaPearl.MinDomainVariableSelection{false}()
         status = @time SeaPearl.solve!(model; variableHeuristic=variableSelection)
@@ -410,17 +410,17 @@
                 tasks[i,j] = SeaPearl.IntVar(0, timeLimit, "task_"*string(i)*"_"*string(j), trailer)
                 endTask[i,j] = SeaPearl.IntVarViewOffset(tasks[i,j], processingTime[i,j], "end_"*string(i)*"_"*string(j))
                 SeaPearl.addVariable!(model, tasks[i,j])
-                push!(model.constraints, SeaPearl.LessOrEqual(endTask[i,j], objectif, trailer))
+                SeaPearl.addConstraint!(model, SeaPearl.LessOrEqual(endTask[i,j], objectif, trailer))
             end
         end
 
         for i in 1:nbTask
-            push!(model.constraints, SeaPearl.Disjunctive([tasks[i,j] for j in 1:nbMachine], 
+            SeaPearl.addConstraint!(model, SeaPearl.Disjunctive([tasks[i,j] for j in 1:nbMachine], 
                                                             [processingTime[i,j] for j in 1:nbMachine],
                                                             trailer))
         end
         for j in 1:nbMachine
-            push!(model.constraints, SeaPearl.Disjunctive([tasks[i,j] for i in 1:nbTask], 
+            SeaPearl.addConstraint!(model, SeaPearl.Disjunctive([tasks[i,j] for i in 1:nbTask], 
                                                             [processingTime[i,j] for i in 1:nbTask],
                                                             trailer))
         end

--- a/test/CP/core/fixPoint.jl
+++ b/test/CP/core/fixPoint.jl
@@ -19,8 +19,8 @@
         SeaPearl.addVariable!(model, t)
         SeaPearl.addVariable!(model, u)
 
-        push!(model.constraints, constraint)
-        push!(model.constraints, constraint3)
+        SeaPearl.addConstraint!(model, constraint)
+        SeaPearl.addConstraint!(model, constraint3)
         feasability, prunedDomains = SeaPearl.fixPoint!(model)
         
         rightPruning = SeaPearl.CPModification("x" => [2, 3, 4],"z" => [11, 12, 13, 14, 15],"y" => [7, 8])
@@ -34,7 +34,7 @@
         @test length(t.domain) == 5
 
         constraint2 = SeaPearl.Equal(y, z, trailer)
-        push!(model.constraints, constraint2)
+        SeaPearl.addConstraint!(model, constraint2)
 
         SeaPearl.fixPoint!(model, Array{SeaPearl.Constraint}([constraint2]))
 
@@ -45,7 +45,7 @@
         @test SeaPearl.isbound(t)
 
         constraint4 = SeaPearl.Equal(u, z, trailer)
-        push!(model.constraints, constraint4)
+        SeaPearl.addConstraint!(model, constraint4)
 
         feasability2, pruned = SeaPearl.fixPoint!(model, Array{SeaPearl.Constraint}([constraint4]))
         @test !feasability2

--- a/test/CP/core/model.jl
+++ b/test/CP/core/model.jl
@@ -255,4 +255,31 @@
         @test model.statistics.numberOfNodesBeforeRestart == 0
         @test model.statistics.numberOfSolutionsBeforeRestart == 0
     end
+
+    @testset "triggerInfeasible!" begin
+        
+        trailer = SeaPearl.Trailer()
+        model = SeaPearl.CPModel(trailer)
+        
+        x = SeaPearl.IntVar(1, 2, "x", trailer)
+        y = SeaPearl.IntVar(1, 2, "y", trailer)
+        z = SeaPearl.IntVar(1, 2, "z", trailer)
+
+        SeaPearl.addVariable!(model, x)
+        SeaPearl.addVariable!(model, y)
+        SeaPearl.addVariable!(model, z)
+        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        push!(model.constraints, SeaPearl.NotEqual(y, z, trailer))
+
+        constraint = model.constraints[1]
+
+        SeaPearl.triggerInfeasible!(constraint, model)
+        @test model.statistics.infeasibleStatusPerVariable["x"] == 1
+        @test model.statistics.infeasibleStatusPerVariable["y"] == 2
+
+        constraint = model.constraints[2]
+        SeaPearl.triggerInfeasible!(constraint, model)
+        @test model.statistics.infeasibleStatusPerVariable["y"] == 3
+        @test model.statistics.infeasibleStatusPerVariable["z"] == 1
+    end
 end

--- a/test/CP/core/model.jl
+++ b/test/CP/core/model.jl
@@ -82,8 +82,8 @@
 
         constraint = SeaPearl.EqualConstant(x, 3, trailer)
         constraint2 = SeaPearl.Equal(x, y, trailer)
-        push!(model.constraints, constraint)
-        push!(model.constraints, constraint2)
+        SeaPearl.addConstraint!(model, constraint)
+        SeaPearl.addConstraint!(model, constraint2)
 
         SeaPearl.fixPoint!(model)
 
@@ -240,9 +240,9 @@
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
         SeaPearl.addVariable!(model, z)
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(y, z, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, z, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(y, z, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, z, trailer))
 
         SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) 
         @test model.statistics.numberOfInfeasibleSolutionsBeforeRestart == 2
@@ -268,18 +268,19 @@
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
         SeaPearl.addVariable!(model, z)
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(y, z, trailer))
 
-        constraint = model.constraints[1]
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(y, z, trailer))
 
-        SeaPearl.triggerInfeasible!(constraint, model)
+
         @test model.statistics.infeasibleStatusPerVariable["x"] == 1
         @test model.statistics.infeasibleStatusPerVariable["y"] == 2
-
-        constraint = model.constraints[2]
-        SeaPearl.triggerInfeasible!(constraint, model)
-        @test model.statistics.infeasibleStatusPerVariable["y"] == 3
         @test model.statistics.infeasibleStatusPerVariable["z"] == 1
+
+        constraint = model.constraints[1]
+        SeaPearl.triggerInfeasible!(constraint, model)
+        @test model.statistics.infeasibleStatusPerVariable["x"] == 2
+        @test model.statistics.infeasibleStatusPerVariable["y"] == 3
+        
     end
 end

--- a/test/CP/core/search/dfs.jl
+++ b/test/CP/core/search/dfs.jl
@@ -26,7 +26,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandDfs!(toCall, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Infeasible
@@ -40,7 +40,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandDfs!(toCall, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :FoundSolution
@@ -55,7 +55,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandDfs!(toCall, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Feasible
@@ -89,7 +89,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.DFSearch(), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic())== :FoundSolution
@@ -124,7 +124,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection()) == :Infeasible
 
@@ -136,7 +136,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 1
@@ -150,7 +150,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 2
@@ -168,7 +168,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Optimal
         @test model.statistics.solutions[1] == Dict("x" => 3,"y" => 3)
@@ -180,7 +180,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic)) == :Optimal
@@ -198,7 +198,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(); out_solver=true) == :FoundSolution
         @test length(model.statistics.solutions) == 1
@@ -210,7 +210,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic); out_solver=true) == :FoundSolution
@@ -305,9 +305,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()
@@ -421,9 +421,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()

--- a/test/CP/core/search/ilds.jl
+++ b/test/CP/core/search/ilds.jl
@@ -26,7 +26,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandIlds!(toCall,0,0,nothing, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(),nothing) == :Infeasible
@@ -40,7 +40,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandIlds!(toCall,0,0,nothing, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(),nothing) == :FoundSolution
@@ -55,7 +55,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandIlds!(toCall,0,2,nothing, model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(),nothing) == :Feasible
@@ -80,7 +80,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.ILDSearch(), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :FoundSolution
@@ -118,7 +118,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection()) == :Infeasible
 
@@ -130,7 +130,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 1
@@ -144,7 +144,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 2
@@ -162,7 +162,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Optimal
         @test model.statistics.solutions[1] == Dict("x" => 3,"y" => 3)
@@ -174,7 +174,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic)) == :Optimal
@@ -190,8 +190,8 @@
         SeaPearl.addVariable!(model, x2)
         SeaPearl.addVariable!(model, x3)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Optimal
         #in this specific finding order with the given heuristic and iLDS method.
@@ -215,7 +215,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(); out_solver=true) == :FoundSolution
         @test length(model.statistics.solutions) == 1
@@ -227,7 +227,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.ILDSearch(), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic); out_solver=true) == :FoundSolution
@@ -322,9 +322,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()
@@ -437,9 +437,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()

--- a/test/CP/core/search/rbs.jl
+++ b/test/CP/core/search/rbs.jl
@@ -28,7 +28,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandRbs!(toCall, model, 1, search, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Infeasible
@@ -42,7 +42,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandRbs!(toCall, model, 1, search, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :FoundSolution
@@ -59,7 +59,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.expandRbs!(toCall, model, 10, search, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Feasible
@@ -93,7 +93,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10, 5), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :FoundSolution
@@ -114,7 +114,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.geometricRBSearch{SeaPearl.VisitedNodeCriteria}(10, 5, 1.1), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic())== :FoundSolution
@@ -131,7 +131,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.geometricRBSearch{SeaPearl.VisitedNodeCriteria}(10, 1, 1.1), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic())== :FoundSolution
@@ -147,7 +147,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         toCall = Stack{Function}()
         @test SeaPearl.initroot!(toCall, SeaPearl.lubyRBSearch{SeaPearl.VisitedNodeCriteria}(10,5), model, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic())== :FoundSolution
@@ -173,7 +173,7 @@
             y = SeaPearl.IntVar(3, 3, "y", trailer)
             SeaPearl.addVariable!(model, x)
             SeaPearl.addVariable!(model, y)
-            push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+            SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
             toCall = Stack{Function}()
             @test SeaPearl.expandRbs!(toCall, model, 1, criteria, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Infeasible
@@ -190,7 +190,7 @@
             y = SeaPearl.IntVar(2, 3, "y", trailer)
             SeaPearl.addVariable!(model, x)
             SeaPearl.addVariable!(model, y)
-            push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+            SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
             toCall = Stack{Function}()
             @test SeaPearl.expandRbs!(toCall, model, 1, criteria, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Feasible
@@ -211,7 +211,7 @@
             y = SeaPearl.IntVar(2, 3, "y", trailer)
             SeaPearl.addVariable!(model, x)
             SeaPearl.addVariable!(model, y)
-            push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+            SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
             toCall = Stack{Function}()
             @test SeaPearl.expandRbs!(toCall, model, 2, criteria, SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Feasible
@@ -253,7 +253,7 @@
         y = SeaPearl.IntVar(3, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection()) == :Infeasible
 
@@ -265,7 +265,7 @@
         y = SeaPearl.IntVar(2, 2, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 1
 
@@ -278,7 +278,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection()) == :Optimal
         @test length(model.statistics.solutions) == 2
@@ -296,7 +296,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic()) == :Optimal
         @test model.statistics.solutions[1] == Dict("x" => 3,"y" => 3)
@@ -308,7 +308,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic)) == :Optimal
@@ -326,7 +326,7 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(); out_solver=true) == :FoundSolution
         @test length(model.statistics.solutions) == 1
         @test model.statistics.solutions[1] == Dict("x" => 3,"y" => 3)
@@ -337,7 +337,7 @@
         y = SeaPearl.IntVar(2, 3, "y", model.trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, model.trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, model.trailer))
 
         my_heuristic(x::SeaPearl.IntVar; cpmodel=nothing) = minimum(x.domain)
         @test SeaPearl.search!(model, SeaPearl.staticRBSearch{SeaPearl.VisitedNodeCriteria}(10,10), SeaPearl.MinDomainVariableSelection(), SeaPearl.BasicHeuristic(my_heuristic); out_solver=true) == :FoundSolution
@@ -426,9 +426,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()
@@ -535,9 +535,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         # define the variable selection
         variableSelection = SeaPearl.MinDomainVariableSelection()

--- a/test/CP/valueselection/learning/learnedheuristic.jl
+++ b/test/CP/valueselection/learning/learnedheuristic.jl
@@ -104,9 +104,9 @@
         SeaPearl.addVariable!(model, x3)
         SeaPearl.addVariable!(model, x4)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x2, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x3, x4, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x2, x3, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x3, x4, trailer))
 
         lh = SeaPearl.LearnedHeuristic(agent)
         SeaPearl.update_with_cpmodel!(lh, model)

--- a/test/CP/valueselection/learning/utils.jl
+++ b/test/CP/valueselection/learning/utils.jl
@@ -10,8 +10,8 @@
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
         SeaPearl.addVariable!(model, z; branchable=false)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
         lh = SeaPearl.LearnedHeuristic(agent)
 
@@ -32,8 +32,8 @@
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
         lh = SeaPearl.LearnedHeuristic(agent)
         SeaPearl.update_with_cpmodel!(lh, model)
@@ -78,8 +78,8 @@
         y = SeaPearl.IntVar(6, 8, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
         lh = SeaPearl.LearnedHeuristic(agent)
         SeaPearl.update_with_cpmodel!(lh, model)

--- a/test/CP/variableselection/failureBased.jl
+++ b/test/CP/variableselection/failureBased.jl
@@ -1,0 +1,49 @@
+
+@testset "failureBased.jl" begin
+    @testset "FailureBasedVariableSelection{TakeObjective=true} " begin 
+        trailer = SeaPearl.Trailer()
+        cpmodel = SeaPearl.CPModel(trailer)
+        x1 = SeaPearl.IntVar(1, 4, "x1", trailer)
+        x2 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        x3 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        y = SeaPearl.IntVar(1, 2, "y", trailer)
+
+        SeaPearl.addVariable!(cpmodel, x1)
+        SeaPearl.addVariable!(cpmodel, x2)
+        SeaPearl.addVariable!(cpmodel, y)
+        SeaPearl.addObjective!(cpmodel,y)
+
+        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
+
+        variableselection = SeaPearl.FailureBasedVariableSelection{true}()
+        @test variableselection(cpmodel) == x2
+
+        SeaPearl.empty!(cpmodel)
+        x1 = SeaPearl.IntVar(1, 3, "x1", trailer)
+        x2 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        x3 = SeaPearl.IntVar(1, 3, "x3", trailer)
+        x4 = SeaPearl.IntVar(1, 3, "x4", trailer)
+        y = SeaPearl.IntVar(1, 2, "y", trailer)
+
+        SeaPearl.addVariable!(cpmodel, x1)
+        SeaPearl.addVariable!(cpmodel, x2)
+        SeaPearl.addVariable!(cpmodel, x3)
+        SeaPearl.addVariable!(cpmodel, x4)
+        SeaPearl.addVariable!(cpmodel, y)
+        SeaPearl.addObjective!(cpmodel,y)
+        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
+        push!(model.constraints, SeaPearl.NotEqual(x1, x3, trailer))
+        push!(model.constraints, SeaPearl.NotEqual(x1, x4, trailer))
+
+        @test variableselection(cpmodel) == x1
+
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+
+        @test variableselection(cpmodel) == x4
+
+
+    end 
+
+end

--- a/test/CP/variableselection/failureBased.jl
+++ b/test/CP/variableselection/failureBased.jl
@@ -1,21 +1,23 @@
 
 @testset "failureBased.jl" begin
-    @testset "FailureBasedVariableSelection{TakeObjective=true} " begin 
+    @testset "FailureBasedVariableSelection{TakeObjective=false} " begin 
         trailer = SeaPearl.Trailer()
         cpmodel = SeaPearl.CPModel(trailer)
         x1 = SeaPearl.IntVar(1, 4, "x1", trailer)
         x2 = SeaPearl.IntVar(1, 3, "x2", trailer)
-        x3 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        x3 = SeaPearl.IntVar(1, 3, "x3", trailer)
         y = SeaPearl.IntVar(1, 2, "y", trailer)
 
         SeaPearl.addVariable!(cpmodel, x1)
         SeaPearl.addVariable!(cpmodel, x2)
+        SeaPearl.addVariable!(cpmodel, x3)
         SeaPearl.addVariable!(cpmodel, y)
         SeaPearl.addObjective!(cpmodel,y)
 
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(y, x2, trailer))
 
-        variableselection = SeaPearl.FailureBasedVariableSelection{true}()
+        variableselection = SeaPearl.FailureBasedVariableSelection{false}()
         @test variableselection(cpmodel) == x2
 
         SeaPearl.empty!(cpmodel)
@@ -31,9 +33,10 @@
         SeaPearl.addVariable!(cpmodel, x4)
         SeaPearl.addVariable!(cpmodel, y)
         SeaPearl.addObjective!(cpmodel,y)
-        push!(model.constraints, SeaPearl.NotEqual(x1, x2, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x1, x3, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x1, x4, trailer))
+
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x3, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x4, trailer))
 
         @test variableselection(cpmodel) == x1
 
@@ -41,9 +44,54 @@
         SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
         SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
 
-        @test variableselection(cpmodel) == x4
+        @test variableselection(cpmodel) == x3
+    end 
 
 
+    @testset "FailureBasedVariableSelection{TakeObjective=true} " begin 
+        trailer = SeaPearl.Trailer()
+        cpmodel = SeaPearl.CPModel(trailer)
+        x1 = SeaPearl.IntVar(1, 4, "x1", trailer)
+        x2 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        x3 = SeaPearl.IntVar(1, 3, "x3", trailer)
+        y = SeaPearl.IntVar(1, 2, "y", trailer)
+
+        SeaPearl.addVariable!(cpmodel, x1)
+        SeaPearl.addVariable!(cpmodel, x2)
+        SeaPearl.addVariable!(cpmodel, x3)
+        SeaPearl.addVariable!(cpmodel, y)
+        SeaPearl.addObjective!(cpmodel, y)
+
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(y, x2, trailer))
+
+        variableselection = SeaPearl.FailureBasedVariableSelection{true}()
+        @test variableselection(cpmodel) == y
+
+        SeaPearl.empty!(cpmodel)
+        x1 = SeaPearl.IntVar(1, 3, "x1", trailer)
+        x2 = SeaPearl.IntVar(1, 3, "x2", trailer)
+        x3 = SeaPearl.IntVar(1, 3, "x3", trailer)
+        x4 = SeaPearl.IntVar(1, 3, "x4", trailer)
+        y = SeaPearl.IntVar(1, 2, "y", trailer)
+
+        SeaPearl.addVariable!(cpmodel, x1)
+        SeaPearl.addVariable!(cpmodel, x2)
+        SeaPearl.addVariable!(cpmodel, x3)
+        SeaPearl.addVariable!(cpmodel, x4)
+        SeaPearl.addVariable!(cpmodel, y)
+        SeaPearl.addObjective!(cpmodel,y)
+
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x2, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x3, trailer))
+        SeaPearl.addConstraint!(cpmodel, SeaPearl.NotEqual(x1, x4, trailer))
+
+        @test variableselection(cpmodel) == x1
+
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+        SeaPearl.triggerInfeasible!(SeaPearl.NotEqual(x3, x4, trailer), cpmodel)
+
+        @test variableselection(cpmodel) == x3
     end 
 
 end

--- a/test/CP/variableselection/variableselection.jl
+++ b/test/CP/variableselection/variableselection.jl
@@ -1,4 +1,5 @@
 @testset "VariableSelection" begin
     include("mindomain.jl")
     include("random.jl")
+    include("failureBased.jl")
 end

--- a/test/RL/representation/default/cp_layer/accessors.jl
+++ b/test/RL/representation/default/cp_layer/accessors.jl
@@ -15,8 +15,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -42,8 +42,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -80,8 +80,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -100,8 +100,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -127,8 +127,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -155,8 +155,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 
@@ -181,8 +181,8 @@ end
     y = SeaPearl.IntVar(2, 3, "y", trailer)
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
     sg = SimpleGraph(g)

--- a/test/RL/representation/default/cp_layer/types.jl
+++ b/test/RL/representation/default/cp_layer/types.jl
@@ -7,9 +7,9 @@
     z = SeaPearl.IntVarViewOpposite(y, "-y")
     SeaPearl.addVariable!(model, x)
     SeaPearl.addVariable!(model, y)
-    push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
-    push!(model.constraints, SeaPearl.NotEqual(z, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
+    SeaPearl.addConstraint!(model, SeaPearl.NotEqual(z, y, trailer))
 
     g = SeaPearl.CPLayerGraph(model)
 

--- a/test/RL/representation/default/defaultstaterepresentation.jl
+++ b/test/RL/representation/default/defaultstaterepresentation.jl
@@ -25,8 +25,8 @@ adj = [0 1 0 1;
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
         dsr = SeaPearl.DefaultStateRepresentation(model)
         SeaPearl.update_representation!(dsr, model, x)
@@ -54,8 +54,8 @@ adj = [0 1 0 1;
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
 
         dsr = SeaPearl.DefaultStateRepresentation(model)
         SeaPearl.update_representation!(dsr, model, x)
@@ -103,8 +103,8 @@ adj = [0 1 0 1;
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
     
 
         dsr = SeaPearl.DefaultStateRepresentation(model)
@@ -123,8 +123,8 @@ adj = [0 1 0 1;
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
-        push!(model.constraints, SeaPearl.NotEqual(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.NotEqual(x, y, trailer))
     
 
         dsr = SeaPearl.DefaultStateRepresentation(model)

--- a/test/experiment/basicmetrics.jl
+++ b/test/experiment/basicmetrics.jl
@@ -130,7 +130,7 @@ agent = RL.Agent(
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         metrics  = SeaPearl.BasicMetrics(model, basicheuristic)
         dt = @elapsed SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), basicheuristic) 
@@ -151,7 +151,7 @@ agent = RL.Agent(
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
 
         metrics  = SeaPearl.BasicMetrics(model, learnedheuristic)
         dt = @elapsed SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), learnedheuristic) 
@@ -176,7 +176,7 @@ agent = RL.Agent(
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
         SeaPearl.addObjective!(model,y)
         metrics  = SeaPearl.BasicMetrics(model, basicheuristic)
         dt = @elapsed SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), basicheuristic) 
@@ -197,7 +197,7 @@ agent = RL.Agent(
         y = SeaPearl.IntVar(2, 3, "y", trailer)
         SeaPearl.addVariable!(model, x)
         SeaPearl.addVariable!(model, y)
-        push!(model.constraints, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
         SeaPearl.addObjective!(model,y)
 
         metrics  = SeaPearl.BasicMetrics(model, learnedheuristic)


### PR DESCRIPTION
This is my proposition for the implementation of the **failure-based search**. 

Basically, in this PR we define a new **variable selection heuristic** that keeps in mind during the search a value for each variable counting the number of time the variable was involved in an unsatifiable constraint during the search. 

This value gives an information about the _difficulty_ of the variable to satisfy all the constraints. The _hardest_ values need to be assigned first during the search to avoid explorating any useless path that is more likely to lead to an infeasible case.

The statistics of the `CPModel` have been updated to support this new feature. 

I also changed the way, we add a constraint in the model to fit the formalism established for `SeaPearl.Addvariable! `and `SeaPearl.Addobjective!` !