### PR TITLE
Removing GPU usage from Test

### DIFF
--- a/test/CP/core/search/dfs.jl
+++ b/test/CP/core/search/dfs.jl
@@ -236,7 +236,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
         target_approximator_model = SeaPearl.CPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 64, Flux.leakyrelu),
@@ -248,7 +248,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
                     
         agent = RL.Agent(
             policy = RL.QBasedPolicy(
@@ -351,7 +351,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
         target_approximator_model = SeaPearl.CPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 64, Flux.leakyrelu),
@@ -363,7 +363,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
                     
         agent = RL.Agent(
             policy = RL.QBasedPolicy(

--- a/test/CP/core/search/ilds.jl
+++ b/test/CP/core/search/ilds.jl
@@ -253,7 +253,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
         target_approximator_model = SeaPearl.CPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 64, Flux.leakyrelu),
@@ -265,7 +265,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
                     
         agent = RL.Agent(
             policy = RL.QBasedPolicy(
@@ -367,7 +367,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
         target_approximator_model = SeaPearl.CPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 64, Flux.leakyrelu),
@@ -379,7 +379,7 @@
                 Flux.Dense(32, 16, Flux.leakyrelu),
             ),
             outputChain = Flux.Dense(16, 4),
-        ) |> gpu
+        ) 
                     
         agent = RL.Agent(
             policy = RL.QBasedPolicy(

--- a/test/CP/valueselection/learning/learnedheuristic.jl
+++ b/test/CP/valueselection/learning/learnedheuristic.jl
@@ -37,7 +37,7 @@
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, 4),
-    ) |> gpu
+    ) 
     target_approximator_model = SeaPearl.CPNN(
         graphChain = Flux.Chain(
             GeometricFlux.GraphConv(3 => 64, Flux.leakyrelu),
@@ -49,7 +49,7 @@
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, 4),
-    ) |> gpu
+    ) 
                 
     agent = RL.Agent(
         policy = RL.QBasedPolicy(

--- a/test/experiment/basicmetrics.jl
+++ b/test/experiment/basicmetrics.jl
@@ -14,7 +14,7 @@ approximator_model = SeaPearl.CPNN(
         Flux.Dense(32, 16, Flux.leakyrelu),
     ),
     outputChain = Flux.Dense(16, 3),
-) |> gpu
+) 
 target_approximator_model = SeaPearl.CPNN(
     graphChain = Flux.Chain(
         GeometricFlux.GraphConv(numInFeatures => 64, Flux.leakyrelu),
@@ -26,7 +26,7 @@ target_approximator_model = SeaPearl.CPNN(
         Flux.Dense(32, 16, Flux.leakyrelu),
     ),
     outputChain = Flux.Dense(16, 3),
-) |> gpu
+) 
 
 
 agent = RL.Agent(

--- a/test/experiment/training.jl
+++ b/test/experiment/training.jl
@@ -21,7 +21,7 @@
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, generator.nb_nodes),
-    ) |> gpu
+    ) 
     target_approximator_model = SeaPearl.CPNN(
         graphChain = Flux.Chain(
             GeometricFlux.GraphConv(numInFeatures => 64, Flux.leakyrelu),
@@ -33,7 +33,7 @@
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, generator.nb_nodes),
-    ) |> gpu
+    ) 
 
     # Agent definition
     agent = RL.Agent(
@@ -119,7 +119,7 @@ end
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, generator.nb_nodes),
-    ) |> gpu
+    ) 
     target_approximator_model = SeaPearl.CPNN(
         graphChain = Flux.Chain(
             GeometricFlux.GraphConv(numInFeatures => 64, Flux.leakyrelu),
@@ -131,7 +131,7 @@ end
             Flux.Dense(32, 16, Flux.leakyrelu),
         ),
         outputChain = Flux.Dense(16, generator.nb_nodes),
-    ) |> gpu
+    ) 
 
     # Agent definition
     agent = RL.Agent(


### PR DESCRIPTION
I just saw that we recently introduced GPU usage during the tests by mistake.

It's not necessarly an issue (it helped me realize that CUDA wasn't working properly on the CIRRELT config) but I'm not sure if it should be the default behavior. If no CUDA installation is detected it won't try to use it though.

What are your thoughts about this ?