### PR TITLE
AllDifferent optimization

### DIFF
--- a/src/CP/constraints/compacttable.jl
+++ b/src/CP/constraints/compacttable.jl
@@ -1,5 +1,3 @@
-include("datasstructures/rsparsebitset.jl")
-
 """
     TableConstraint
 
@@ -124,18 +122,6 @@ function TableConstraint(variables::Vector{<:AbstractIntVar}, table::Matrix{Int}
     end
 
     return constraint
-end
-
-"""
-    bitVectorToUInt64Vector(bitset)::Vector{UInt64}
-
-Convert a Julia BitVector to a vector preformatted for the RSparseBitSet{UInt64}.
-
-# Arguments
-- `bitset::BitVector`: the BitVector to convert.
-"""
-function bitVectorToUInt64Vector(bitset::BitVector)::Vector{UInt64}
-    return [bitreverse(chunk) for chunk in bitset.chunks]
 end
 
 """

--- a/src/CP/constraints/constraints.jl
+++ b/src/CP/constraints/constraints.jl
@@ -1,3 +1,6 @@
+include("datasstructures/rsparsebitset.jl")
+
+
 include("absolute.jl")
 include("disjunctive.jl")
 include("alldifferent.jl")

--- a/src/CP/constraints/datasstructures/rsparsebitset.jl
+++ b/src/CP/constraints/datasstructures/rsparsebitset.jl
@@ -35,7 +35,7 @@ struct RSparseBitSet{T}
     end
 end
 
-const RSparseBitSet(size::Int, trailer) = RSparseBitSet{UInt64}(size::Int, trailer)
+RSparseBitSet(size::Int, trailer) = RSparseBitSet{UInt64}(size::Int, trailer)
 
 
 """
@@ -104,6 +104,27 @@ function intersectIndex(set::RSparseBitSet{T}, m::Vector{T})::Int where T <: Uns
     return -1
 end
 
+"""
+    bitVectorToUInt64Vector(bitset)::Vector{UInt64}
+
+Convert a Julia BitVector to a vector preformatted for the RSparseBitSet{UInt64}.
+
+# Arguments
+- `bitset::BitVector`: the BitVector to convert.
+"""
+function bitVectorToUInt64Vector(bitset::BitVector)::Vector{UInt64}
+    return [bitreverse(chunk) for chunk in bitset.chunks]
+end
+
+function Base.BitVector(set::RSparseBitSet{UInt64})
+    bitvector = BitVector(undef, 8*sizeof(UInt64)*length(set.words))
+    bitvector .= false
+    for i = set.limit.value:-1:1
+        offset = set.index[i]
+        bitvector.chunks[offset] = bitreverse(set.words[offset].value)
+    end
+    return bitvector
+end
 
 function Base.isempty(set::RSparseBitSet{T})::Bool where T <: Unsigned
     return set.limit.value == 0

--- a/src/CP/core/search/search.jl
+++ b/src/CP/core/search/search.jl
@@ -2,7 +2,6 @@
 include("dfs.jl")
 include("ilds.jl")
 include("rbs.jl")
-include("strategies.jl")
 
 
 """

--- a/src/CP/variables/BoolVar.jl
+++ b/src/CP/variables/BoolVar.jl
@@ -8,6 +8,7 @@ struct BoolVar <: AbstractBoolVar
     onDomainChange      ::Array{Constraint}
     domain              ::SeaPearl.BoolDomain
     id                  ::String
+    children            ::Set{AbstractBoolVar}
 end
 
 """
@@ -19,7 +20,7 @@ and that will be backtracked by `trailer`.
 function BoolVar(id::String, trailer::Trailer)
     dom = BoolDomain(trailer)
 
-    return BoolVar(Constraint[], dom, id)
+    return BoolVar(Constraint[], dom, id, Set{AbstractBoolVar}())
 end
 
 function Base.show(io::IO, var::BoolVar)

--- a/src/CP/variables/BoolVarView.jl
+++ b/src/CP/variables/BoolVarView.jl
@@ -1,3 +1,6 @@
+addChildrenVariable!(x::BoolVar, y::BoolVarView) = push!(x.children, y)
+addChildrenVariable!(x::BoolVarView, y::BoolVarView) = addChildrenVariable!(x.x, y)
+
 struct BoolDomainViewNot <: BoolDomainView
     orig            ::AbstractBoolDomain
 end
@@ -14,7 +17,9 @@ struct BoolVarViewNot <: BoolVarView
     """
     function BoolVarViewNot(x::AbstractBoolVar, id::String)
         dom = BoolDomainViewNot(x.domain)
-        return new(x, dom, id)
+        var = new(x, dom, id)
+        addChildrenVariable!(x, var)
+        return var
     end
 end
 
@@ -89,3 +94,5 @@ function Base.iterate(dom::BoolDomainViewNot, state=1)
 end
 
 parentValue(::BoolVarViewNot, v::Bool) = ! v
+childrenValue(::BoolVar, v::Bool) = v
+childrenValue(y::BoolVarViewNot, v::Bool) = ! childrenValue(y.x, v)

--- a/src/CP/variables/IntVar.jl
+++ b/src/CP/variables/IntVar.jl
@@ -8,6 +8,7 @@ struct IntVar <: AbstractIntVar
     onDomainChange      ::Array{Constraint}
     domain              ::SeaPearl.IntDomain
     id                  ::String
+    children            ::Set{AbstractIntVar}
 end
 
 """
@@ -21,7 +22,7 @@ function IntVar(min::Int, max::Int, id::String, trailer::Trailer)
 
     dom = IntDomain(trailer, max - min + 1, offset)
 
-    return IntVar(Constraint[], dom, id)
+    return IntVar(Constraint[], dom, id, Set{AbstractIntVar}())
 end
 
 function Base.show(io::IO, var::IntVar)

--- a/src/CP/variables/IntVarView.jl
+++ b/src/CP/variables/IntVarView.jl
@@ -1,3 +1,6 @@
+addChildrenVariable!(x::IntVar, y::IntVarView) = push!(x.children, y)
+addChildrenVariable!(x::IntVarView, y::IntVarView) = addChildrenVariable!(x.x, y)
+
 struct IntDomainViewMul <: IntDomainView
     orig            ::AbstractIntDomain
     a               ::Int
@@ -18,7 +21,9 @@ struct IntVarViewMul <: IntVarView
     function IntVarViewMul(x::AbstractIntVar, a::Int, id::String)
         @assert a > 0
         dom = IntDomainViewMul(x.domain, a)
-        return new(x, a, dom, id)
+        var = new(x, a, dom, id)
+        addChildrenVariable!(x, var)
+        return var
     end
 end
 
@@ -38,7 +43,9 @@ struct IntVarViewOpposite <: IntVarView
     """
     function IntVarViewOpposite(x::AbstractIntVar, id::String)
         dom = IntDomainViewOpposite(x.domain)
-        return new(x, dom, id)
+        var = new(x, dom, id)
+        addChildrenVariable!(x, var)
+        return var
     end
 end
 
@@ -60,7 +67,9 @@ struct IntVarViewOffset <: IntVarView
     """
     function IntVarViewOffset(x::AbstractIntVar, c::Int, id::String)
         dom = IntDomainViewOffset(x.domain, c)
-        return new(x, c, dom, id)
+        var = new(x, c, dom, id)
+        addChildrenVariable!(x, var)
+        return var
     end
 end
 
@@ -265,3 +274,7 @@ end
 parentValue(y::IntVarViewMul, v::Int) = v ÷ y.a
 parentValue(y::IntVarViewOffset, v::Int) = v - y.c
 parentValue(::IntVarViewOpposite, v::Int) = - v
+childrenValue(::IntVar, v::Int) = v
+childrenValue(y::IntVarViewMul, v::Int) = childrenValue(y.x, v) * y.a
+childrenValue(y::IntVarViewOffset, v::Int) = childrenValue(y.x, v) + y.c
+childrenValue(y::IntVarViewOpposite, v::Int) = - childrenValue(y.x, v)


### PR DESCRIPTION
After running some tests on Eternity 2, I observed that the search was suprisingly slow espacially the AllDiff constraint.

Thus I optimizied the consrtaint a bit (still not perfect though), which results in a x2 speedup for eternity2 without learning. This optimization uses ReversibleSparseBitSets (as in Compact Table) to store the state of the edges of the bipartite graph between 2 propagations, rather than an expensive dictionnary.
I also spotted a lack with the ViewVariable => when modifying a ViewVariable, the RootVariable corresponding values were not added to CPModification (and many tests were not designed to spot this). I spotted this as it caused the new AllDiff code to fail the NQueens test.