### PR TITLE
Removed rolling-mean computation

### DIFF
--- a/src/experiment/launch_experiment.jl
+++ b/src/experiment/launch_experiment.jl
@@ -80,10 +80,6 @@ function launch_experiment!(
         end
         verbose && println()
     end
-    for j in 1:nbHeuristics
-        #compute slidding mean for each metrics
-        computemean!(metricsArray[j])  #how to handle non basic metrics here ? 
-    end
     
     if !isnothing(evaluator)
         return metricsArray, evaluator.metrics


### PR DESCRIPTION
In the basic metrics, a mean computation is integrated. But this mean uses arbitrary parameters and prevent the possibility to store raw-data in the final csv file. In my opinion this kind of operation should be done in post-treatment, when plotting data, rather than during data-gathering. (this function makes it impossible to use the `storedata` function from SeaPearlExtras)