### PR TITLE
Fix unneeded docstring + inclusion bug

### DIFF
--- a/src/CP/core/search/search.jl
+++ b/src/CP/core/search/search.jl
@@ -2,7 +2,6 @@
 include("dfs.jl")
 include("ilds.jl")
 include("rbs.jl")
-include("strategies.jl")
 
 
 """

--- a/src/CP/core/search/strategies.jl
+++ b/src/CP/core/search/strategies.jl
@@ -1,4 +1,5 @@
-"""SeaPearl Provides several pre-implemented search strategy to explore the search tree in a certain way. The specific strategy has to 
+"""
+SeaPearl Provides several pre-implemented search strategy to explore the search tree in a certain way. The specific strategy has to 
 be specified in the search! function. The search strategy choose how the _toCall_ Stack will be filled and empty ( ie. which branch will 
 be explored at a certain node ).
 """    
@@ -41,34 +42,30 @@ struct lubyRBSearch{C} <: RBSearch{C}
 end
 
 abstract type VisitedNodeCriteria <: ExpandCriteria end
-"""
-    function (criteria::VisitedNodeCriteria)(model::CPModel, limit::Int64)::Bool
 
-The stopping criteria is the number of Visited nodes in the search tree. Here the inequality is large because 
-we don't consider the root node of the tree as a visited node. 
+"""
+    function (criteria<:ExpandCriteria)(model::CPModel, limit::Int64)::Bool
+
+Return a boolean, with `true` meaning that the stopping criteria has been reached
 """
 function (criteria::RBSearch{VisitedNodeCriteria})(model::CPModel, limit::Int64)::Bool
-    return model.statistics.numberOfNodesBeforeRestart <= limit   #CAUTION : Here the inequality is large
+    return model.statistics.numberOfNodesBeforeRestart <= limit
+    # The stopping criteria is the number of Visited nodes in the search tree. 
+    # Here the inequality is large because we don't consider the root node of the tree as a visited node. 
 end
 
 abstract type InfeasibleNodeCriteria <: ExpandCriteria end 
-"""
-    function (criteria::InfeasibleNodeCriteria)(model::CPModel, limit::Int64)::Bool
 
-The stopping criteria is the number of visited nodes where the partial solution led to a case where all constraints were not respected. 
-(ie. leading to the :Infeasible case in the expandRbs! function)
-"""
 function (criteria::RBSearch{InfeasibleNodeCriteria})(model::CPModel, limit::Int64)::Bool
     return model.statistics.numberOfInfeasibleSolutionsBeforeRestart < limit
+    # The stopping criteria is the number of visited nodes where the partial solution led to a case where all constraints were not respected. 
+    # (ie. leading to the :Infeasible case in the expandRbs! function)
 end
 
 abstract type SolutionFoundCriteria <: ExpandCriteria end 
-"""
-    function (criteria::SolutionFoundCriteria)(model::CPModel, limit::Int64)::Bool
 
-The stopping criteria is the number of Solution Found during the search. As long as L solutions have been found, the search restart at the 
-top of the tree.
-"""
 function (criteria::RBSearch{SolutionFoundCriteria})(model::CPModel, limit::Int64)::Bool
     return model.statistics.numberOfSolutionsBeforeRestart < limit
+    # The stopping criteria is the number of Solution Found during the search. 
+    # As long as L solutions have been found, the search restart at the top of the tree.
 end

--- a/src/experiment/metrics/basicmetrics.jl
+++ b/src/experiment/metrics/basicmetrics.jl
@@ -42,13 +42,10 @@ end
 BasicMetrics(model::CPModel, heuristic::ValueSelection; meanOver=20) = BasicMetrics{(!isnothing(model.objective)) ? TakeObjective : DontTakeObjective ,typeof(heuristic)}(heuristic,meanOver)
 
 """
-    function (metrics::BasicMetrics{DontTakeObjective, BasicHeuristic})(model::CPModel,dt::Float64)
+    function (metrics<:BasicMetrics)(model::CPModel,dt::Float64)
 
 The function is called after a search on a Constraint Programming Model.
-For a basic heuristic on a problem that doesn't consider an objective, the function stores: 
-- the number of nodes visited to find each solution of an instance. 
-- the number of nodes visited to complete the search (ie. prove optimality).
-- the computing time required to complete each search (ie. prove optimality).
+It updates all the metrics during the search.
 """
 function (metrics::BasicMetrics{DontTakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
@@ -61,16 +58,6 @@ function (metrics::BasicMetrics{DontTakeObjective, <:BasicHeuristic})(model::CPM
     return
 end 
 
-"""
-    function (metrics::BasicMetrics{TakeObjective, BasicHeuristic})(model::CPModel,dt::Float64)
-
-The function is called after a search on a Constraint Programming Model.
-For a basic heuristic on a problem that considers an objective, the function stores: 
-- the number of nodes visited to find each solution of an instance. 
-- the number of nodes visited to complete the search (ie. prove optimality).
-- the computing time required to complete each search (ie. prove optimality).
-- the relative scores of every solution found compared to the optimal solution.
-"""
 function (metrics::BasicMetrics{TakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
@@ -85,17 +72,6 @@ function (metrics::BasicMetrics{TakeObjective, <:BasicHeuristic})(model::CPModel
 
 end 
 
-"""
-    function (metrics::BasicMetrics{DontTakeObjective, LearnedHeuristic})(model::CPModel,dt::Float64)
-
-The function is called after a search on a Constraint Programming Model.
-For a learnedheuristic on a problem that doesn't consider an objective, the function stores: 
-- the number of nodes visited to find each solution of an instance. 
-- the number of nodes visited to complete the search (ie. prove optimality).
-- the computing time required to complete each search (ie. prove optimality).
-- the total reward of each search.
-- the total loss of each search.
-"""
 function (metrics::BasicMetrics{DontTakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
@@ -109,18 +85,7 @@ function (metrics::BasicMetrics{DontTakeObjective, <:LearnedHeuristic})(model::C
     return
 end 
 
-"""
-    function (metrics::BasicMetrics{TakeObjective, LearnedHeuristic})(model::CPModel,dt::Float64) 
 
-The function is called after a search on a Constraint Programming Model.
-For a learnedheuristic on a problem that considers an objective, the function stores: 
-- the number of nodes visited to find each solution of an instance. 
-- the number of nodes visited to complete the search (ie. prove optimality).
-- the computing time required to complete each search (ie. prove optimality).
-- the relative scores of every solution found compared to the optimal solution.
-- the total reward of each search.
-- the total loss of each search.
-"""
 function (metrics::BasicMetrics{TakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64) 
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))


### PR DESCRIPTION
Since a few commits, we have a lot of warnings at compilation time. I tracked these warnings to 2 main issues:

- a double inclusion of `strategies.jl`
- redefinitions of docstrings, because Julia isn't able to dissociate different version of the same struct used as a function (refer to the modified files for an example)

Now  everything should compile smoothly (2 warnings remain, one because of the redefinition of `Base.repeat` in a CUDA friendly fashion from a code proposed on their github, we need this function while it's not added to the official release and while GeometricFlux prevent the use of CUDAv3, the other from RLEnvironments and nothing can be done about that)