### PR TITLE
Add an input layer for node and edge features

### DIFF
--- a/src/RL/nn_structures/fullfeaturedcpnn.jl
+++ b/src/RL/nn_structures/fullfeaturedcpnn.jl
@@ -10,6 +10,8 @@ This structure is here to provide a flexible way to create a nn model which resp
 Making modification on the graph, then extract one node feature and modify it.
 """
 Base.@kwdef struct FullFeaturedCPNN <: NNStructure
+    nodeInputChain::Flux.Chain = Flux.Chain()
+    edgeInputChain::Flux.Chain = Flux.Chain()
     graphChain::Flux.Chain = Flux.Chain()
     nodeChain::Flux.Chain = Flux.Chain()
     globalChain::Flux.Chain = Flux.Chain()
@@ -28,8 +30,19 @@ function (nn::FullFeaturedCPNN)(states::BatchedDefaultTrajectoryState)
     allValuesIdx = states.allValuesIdx
     actionSpaceSize = size(allValuesIdx, 1)
 
+    # node pre-processing
+    targetSize = (:, size(states.fg.nf)[2:end]...)
+    nodeFeatures = sizeof(states.fg.nf) == 0 ? states.fg.nf : reshape(nn.nodeInputChain(flatten_batch(states.fg.nf)), targetSize)
+
+    # edge pre-processing
+    targetSize = (:, size(states.fg.ef)[2:end]...)
+    edgeFeatures = sizeof(states.fg.ef) == 0 ? states.fg.ef : reshape(nn.edgeInputChain(flatten_batch(states.fg.ef)), targetSize)
+
+    fg = BatchedFeaturedGraph{Float32}(states.fg.graph, nodeFeatures, edgeFeatures, states.fg.gf)
+    
+
     # chain working on the graph(s) with the GNNs
-    featuredGraph = nn.graphChain(states.fg)
+    featuredGraph = nn.graphChain(fg)
     nodeFeatures = featuredGraph.nf
     globalFeatures = featuredGraph.gf
 

--- a/test/RL/nn_structures/cpnn.jl
+++ b/test/RL/nn_structures/cpnn.jl
@@ -1,6 +1,6 @@
 @testset "cpnn.jl" begin
 
-    @testset "CPNN w/o global features" begin 
+    @testset "CPNN" begin 
         modelNN = SeaPearl.CPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 3),
@@ -17,6 +17,50 @@
 
         graphs = Matrix.(adjacency_matrix.([random_regular_graph(10, 4) for i = 1:4]))
         nodeFeatures = [rand(3, 10) for i = 1:4]
+        featuredGraphs = [FeaturedGraph(g; nf=nf) for (g, nf) in zip(graphs, nodeFeatures)]
+
+        trajectoryVector = SeaPearl.DefaultTrajectoryState.(featuredGraphs, rand(1:10, 4))
+        nnInput = trajectoryVector |> cpu
+
+        output = modelNN(nnInput)
+
+        @test size(output) == (2, 4)
+
+        grad = gradient(nnInput) do inp
+            modelNN(inp)[2,2]
+        end
+        grad = grad[1]
+
+        @test isnothing(grad.allValuesIdx)
+        @test isnothing(grad.variableIdx)
+        @test isnothing(grad.fg.ef)
+        @test isnothing(grad.fg.gf)
+        @test all(grad.fg.nf[:, :, [1, 3, 4]] .== 0)
+        @test !all(grad.fg.nf[:, :, 2] .== 0)
+        @test all(grad.fg.graph[:, :, [1, 3, 4]] .== 0)
+        @test !all(grad.fg.graph[:, :, 2] .== 0)
+    end
+
+    @testset "CPNN w/ nodeInputChain" begin 
+        modelNN = SeaPearl.CPNN(
+            nodeInputChain = Flux.Chain(
+                Flux.Dense(2, 3)
+            ),
+            graphChain = Flux.Chain(
+                GeometricFlux.GraphConv(3 => 3),
+                GeometricFlux.GraphConv(3 => 3),
+            ),
+            nodeChain = Flux.Chain(
+                Flux.Dense(3, 3),
+                Flux.Dense(3, 3),
+            ),
+            outputChain = Flux.Chain(
+                Flux.Dense(3, 2)
+            )
+        )
+
+        graphs = Matrix.(adjacency_matrix.([random_regular_graph(10, 4) for i = 1:4]))
+        nodeFeatures = [rand(2, 10) for i = 1:4]
         featuredGraphs = [FeaturedGraph(g; nf=nf) for (g, nf) in zip(graphs, nodeFeatures)]
 
         trajectoryVector = SeaPearl.DefaultTrajectoryState.(featuredGraphs, rand(1:10, 4))

--- a/test/RL/nn_structures/fullfeaturedcpnn.jl
+++ b/test/RL/nn_structures/fullfeaturedcpnn.jl
@@ -1,6 +1,6 @@
 @testset "fullfeaturedcpnn.jl" begin
     
-    @testset "FullFeaturedCPNN w/o global features" begin
+    @testset "FullFeaturedCPNN" begin
         modelNN = SeaPearl.FullFeaturedCPNN(
             graphChain = Flux.Chain(
                 GeometricFlux.GraphConv(3 => 3),
@@ -17,6 +17,50 @@
 
         graphs = Matrix.(adjacency_matrix.([random_regular_graph(10, 4) for i = 1:4]))
         nodeFeatures = [rand(3, 10) for i = 1:4]
+        featuredGraphs = [FeaturedGraph(g; nf=nf) for (g, nf) in zip(graphs, nodeFeatures)]
+
+        trajectoryVector = SeaPearl.DefaultTrajectoryState.(featuredGraphs, rand(1:10, 4), [rand(1:10, 3) for i=1:4])
+        nnInput = trajectoryVector |> cpu
+
+        output = modelNN(nnInput)
+
+        @test size(output) == (3, 4)
+
+        grad = gradient(nnInput) do inp
+            modelNN(inp)[2,2]
+        end
+        grad = grad[1]
+
+        @test isnothing(grad.allValuesIdx)
+        @test isnothing(grad.variableIdx)
+        @test isnothing(grad.fg.ef)
+        @test isnothing(grad.fg.gf)
+        @test all(grad.fg.nf[:, :, [1, 3, 4]] .== 0)
+        @test !all(grad.fg.nf[:, :, 2] .== 0)
+        @test all(grad.fg.graph[:, :, [1, 3, 4]] .== 0)
+        @test !all(grad.fg.graph[:, :, 2] .== 0)
+    end
+
+    @testset "FullFeaturedCPNN w/ nodeInputChain" begin
+        modelNN = SeaPearl.FullFeaturedCPNN(
+            nodeInputChain = Flux.Chain(
+                Flux.Dense(2, 3)
+            ),
+            graphChain = Flux.Chain(
+                GeometricFlux.GraphConv(3 => 3),
+                GeometricFlux.GraphConv(3 => 3),
+            ),
+            nodeChain = Flux.Chain(
+                Flux.Dense(3, 3),
+                Flux.Dense(3, 3),
+            ),
+            outputChain = Flux.Chain(
+                Flux.Dense(6, 1)
+            )
+        )
+
+        graphs = Matrix.(adjacency_matrix.([random_regular_graph(10, 4) for i = 1:4]))
+        nodeFeatures = [rand(2, 10) for i = 1:4]
         featuredGraphs = [FeaturedGraph(g; nf=nf) for (g, nf) in zip(graphs, nodeFeatures)]
 
         trajectoryVector = SeaPearl.DefaultTrajectoryState.(featuredGraphs, rand(1:10, 4), [rand(1:10, 3) for i=1:4])


### PR DESCRIPTION
As discussed with @tomsander1998 and @3rdCore, we thought it could be smart to add node-wise layers before the graph layers. It would makes it possible to use normalization on input features, and efficiently resize the features recieved by the GNN.
This has not been tested in depth yet, and it might still be a bit early to merge it.