### PR TITLE
Fixing major leak between training and evaluation data

### DIFF
--- a/src/CP/valueselection/learning/learnedheuristic.jl
+++ b/src/CP/valueselection/learning/learnedheuristic.jl
@@ -34,7 +34,8 @@ mutable struct LearnedHeuristic{SR<:AbstractStateRepresentation, R<:AbstractRewa
     reward::Union{Nothing, R}
     search_metrics::Union{Nothing, SearchMetrics}
     firstActionTaken::Bool
-    LearnedHeuristic{SR, R, A}(agent::RL.Agent) where {SR, R, A}= new{SR, R, A}(agent, nothing, nothing, nothing, nothing, nothing, nothing, false)
+    trainmode::Bool
+    LearnedHeuristic{SR, R, A}(agent::RL.Agent) where {SR, R, A}= new{SR, R, A}(agent, nothing, nothing, nothing, nothing, nothing, nothing, false, true)
 end
 
 """
@@ -55,7 +56,9 @@ function (valueSelection::LearnedHeuristic)(::Type{InitializingPhase}, model::CP
     # Reset the agent, useful for things like recurrent networks
     Flux.reset!(valueSelection.agent)
 
-    valueSelection.agent(RL.PRE_EPISODE_STAGE, env)
+    if valueSelection.trainmode
+        valueSelection.agent(RL.PRE_EPISODE_STAGE, env)
+    end
 end
 
 """
@@ -89,15 +92,19 @@ function (valueSelection::LearnedHeuristic)(PHASE::Type{DecisionPhase}, model::C
 
     #println("Decision  ", env.reward, " ", env.terminal, " ", env.legal_actions, " ", env.legal_actions_mask)
     if valueSelection.firstActionTaken
-        valueSelection.agent(RL.POST_ACT_STAGE, env) # get terminal and reward
+        if valueSelection.trainmode
+            valueSelection.agent(RL.POST_ACT_STAGE, env) # get terminal and reward
+        end
     else
         valueSelection.firstActionTaken = true
     end
 
     action = valueSelection.agent(env) # Choose action
-    # TODO: swap to async computation once in deployment
-    #@async valueSelection.agent(RL.PRE_ACT_STAGE, env, action) # Store state and action
-    valueSelection.agent(RL.PRE_ACT_STAGE, env, action)
+    if valueSelection.trainmode
+        # TODO: swap to async computation once in deployment
+        #@async valueSelection.agent(RL.PRE_ACT_STAGE, env, action) # Store state and action
+        valueSelection.agent(RL.PRE_ACT_STAGE, env, action)
+    end
 
     return action_to_value(valueSelection, action, state(env), model)
 end
@@ -117,9 +124,10 @@ function (valueSelection::LearnedHeuristic)(PHASE::Type{EndingPhase}, model::CPM
     env = get_observation!(valueSelection, model, false_x, true)
     #println("EndingPhase  ", env.reward, " ", env.terminal, " ", env.legal_actions, " ", env.legal_actions_mask)
 
-    valueSelection.agent(RL.POST_ACT_STAGE, env) # get terminal and reward
-
-    valueSelection.agent(RL.POST_EPISODE_STAGE, env)  # let the agent see the last observation
+    if valueSelection.trainmode
+        valueSelection.agent(RL.POST_ACT_STAGE, env) # get terminal and reward
+        valueSelection.agent(RL.POST_EPISODE_STAGE, env)  # let the agent see the last observation
+    end
 
     if CUDA.has_cuda()
         CUDA.reclaim()

--- a/src/CP/valueselection/learning/utils.jl
+++ b/src/CP/valueselection/learning/utils.jl
@@ -7,7 +7,10 @@ you stop updating the weights or the approximator once the training is done. It 
 of the `train!` function to make sure it's training and changed automatically at the end of it but a user can 
 manually change the mode again if he wants.
 """
-Flux.testmode!(lh::LearnedHeuristic, mode = true) = Flux.testmode!(lh.agent, mode) 
+function Flux.testmode!(lh::LearnedHeuristic, mode = true)
+    Flux.testmode!(lh.agent, mode)
+    lh.trainmode = !mode
+end
 
 """
     update_with_cpmodel!(lh::LearnedHeuristic{SR, R, A}, model::CPModel)
@@ -139,7 +142,7 @@ end
 
 Mapping index of Q-value vector to value in the action space when using a FixedOutput.
 """
-function action_to_value(vs::LearnedHeuristic{SR, R, FixedOutput}, action::Int64, state::AbstractTrajectoryState, model::CPModel) where {SR <: DefaultStateRepresentation, R}
+function action_to_value(vs::LearnedHeuristic{SR, R, FixedOutput}, action::Int64, state::AbstractTrajectoryState, model::CPModel) where {SR <: AbstractStateRepresentation, R}
     return vs.action_space[action]
 end
 

--- a/src/RL/representation/tsptw/tsptwstaterepresentation.jl
+++ b/src/RL/representation/tsptw/tsptwstaterepresentation.jl
@@ -29,13 +29,14 @@ end
 
 TsptwStateRepresentation(model::CPModel) = TsptwStateRepresentation{TsptwFeaturization, TsptwTrajectoryState}(model)
 
+# This function is used for legacy. It enables compatibility with the experiments present during CPAIOR 2021, with variableOutputGNN
 function TsptwTrajectoryState(sr::TsptwStateRepresentation{F, TsptwTrajectoryState}) where F
     # TODO change this once the InitializingPhase is fixed
     if isnothing(sr.variableIdx)
         sr.variableIdx = 1
     end
     if isnothing(sr.possibleValuesIdx)
-        throw(ErrorException("Unable to build a DefaultTrajectoryState, when the possible values vector is nothing."))
+        throw(ErrorException("Unable to build a TsptwTrajectoryState, when the possible values vector is nothing."))
     end
 
     n = size(sr.dist, 1)
@@ -43,6 +44,25 @@ function TsptwTrajectoryState(sr::TsptwStateRepresentation{F, TsptwTrajectorySta
     edgeFeatures = build_edge_feature(adj, sr.dist)
     fg = GeometricFlux.FeaturedGraph(adj; nf=sr.nodeFeatures, ef=edgeFeatures)
     return TsptwTrajectoryState(fg, sr.variableIdx, sr.possibleValuesIdx)
+end
+
+function DefaultTrajectoryState(sr::TsptwStateRepresentation{F, DefaultTrajectoryState}) where F
+    # TODO change this once the InitializingPhase is fixed
+    if isnothing(sr.variableIdx)
+        sr.variableIdx = 1
+    end
+    if isnothing(sr.possibleValuesIdx)
+        throw(ErrorException("Unable to build a TsptwTrajectoryState, when the possible values vector is nothing."))
+    end
+
+    n = size(sr.dist, 1)
+    adj = ones(Int, n, n) - I
+    edgeFeatures = build_edge_feature(adj, sr.dist)
+    fg = GeometricFlux.FeaturedGraph(adj; nf=sr.nodeFeatures, ef=edgeFeatures)
+
+    actionSpace = collect(1:n)
+
+    return DefaultTrajectoryState(fg, sr.variableIdx, actionSpace)
 end
 
 function get_tsptw_info(model::CPModel)

--- a/src/experiment/evaluation.jl
+++ b/src/experiment/evaluation.jl
@@ -24,19 +24,24 @@ function SameInstancesEvaluator(valueSelectionArray::Array{H, 1}, generator::Abs
 end
 
 function evaluate(eval::SameInstancesEvaluator, variableHeuristic::AbstractVariableSelection, strategy::S; verbose::Bool=true) where{S<:SearchStrategy}
-
     for j in 1:eval.nbHeuristics
-        testmode!(eval.metrics[1,j].heuristic, true)
+        heuristic = eval.metrics[1,j].heuristic
+        initsize = isa(heuristic, LearnedHeuristic) ? length(heuristic.agent.trajectory) : nothing
+
+        testmode!(heuristic, true)
         for i in 1:eval.nbInstances
             model = eval.instances[i]
             reset_model!(model)
 
-            dt = @elapsed search!(model, strategy, variableHeuristic, eval.metrics[1,j].heuristic)
+            dt = @elapsed search!(model, strategy, variableHeuristic, heuristic)
             eval.metrics[i,j](model,dt)
 
-            verbose && println(typeof(eval.metrics[1,j].heuristic), " evaluated with: ", model.statistics.numberOfNodes, " nodes, taken ", dt, "s, number of solutions found : ", model.statistics.numberOfSolutions)
+            verbose && println(typeof(heuristic), " evaluated with: ", model.statistics.numberOfNodes, " nodes, taken ", dt, "s, number of solutions found : ", model.statistics.numberOfSolutions)
         end 
-        testmode!(eval.metrics[1,j].heuristic, false)
+        testmode!(heuristic, false)
+        if !isnothing(initsize)
+            @assert length(heuristic.agent.trajectory) == initsize "You have leaks in your evaluation pipeline!"
+        end
     end
 end
 

--- a/src/experiment/launch_experiment.jl
+++ b/src/experiment/launch_experiment.jl
@@ -77,7 +77,7 @@ function launch_experiment!(
                 verbose && print(model.statistics.numberOfNodesBeforeRestart, ", ")    
             end
             metricsArray[j](model,dt)  #adding results in the metrics data structure
-            println()
+            verbose && println()
         end
 
         if !isnothing(evaluator) && (i % evaluator.evalFreq == 0)


### PR DESCRIPTION
After a close inspection we detected with @3rdCore an issue in the evaluation pipeline.

Until now SeaPearl has been relying on the function `Flux.testmode!` to prevent training of the NN model on test samples. However this function doesn't prevent the addition of these samples to the memory of the RL agent. We beleive that these samples are then used by RL.jl sampler to provide training samples to the agent. This behavior could explain some other strange behaviors that were observed in the last months (decreasing reward on the train samples, learning despite erroneous reward...).

The fix to this issue is rather simple, and consists in preventing RL.jl to do any update when the heuristic is set in test mode.