### PR TITLE
Add SolutionFound to BasicMetrics

### DIFF
--- a/src/experiment/metrics/basicmetrics.jl
+++ b/src/experiment/metrics/basicmetrics.jl
@@ -30,7 +30,7 @@ It satisfies the two AbstractMetrics requirements:
 mutable struct BasicMetrics{O<:AbstractTakeObjective, H<:ValueSelection} <: AbstractMetrics
     heuristic::H
     nodeVisited::Vector{Vector{Int64}}
-    solutionFound::Vector{Vector{Int64}}
+    solutionFound::Vector{Vector{Bool}}
     meanNodeVisitedUntilfirstSolFound::Vector{Float32}
     meanNodeVisitedUntilEnd::Vector{Float32}
     timeneeded::Vector{Float32}
@@ -54,7 +54,7 @@ It updates all the metrics during the search.
 function (metrics::BasicMetrics{DontTakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
-    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
+    push!(metrics.solutionFound, (x -> !isnothing(x)).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -66,7 +66,7 @@ end
 function (metrics::BasicMetrics{TakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
-    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
+    push!(metrics.solutionFound, (x -> !isnothing(x)).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -81,7 +81,7 @@ end
 function (metrics::BasicMetrics{DontTakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
-    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
+    push!(metrics.solutionFound, (x -> !isnothing(x)).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -96,7 +96,7 @@ end
 function (metrics::BasicMetrics{TakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64) 
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
-    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
+    push!(metrics.solutionFound, (x -> !isnothing(x)).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])

--- a/src/experiment/metrics/basicmetrics.jl
+++ b/src/experiment/metrics/basicmetrics.jl
@@ -15,6 +15,8 @@ It satisfies the two AbstractMetrics requirements:
     heuristic::H                                        ->  The related heuristic for which the metrics stores the results.
     nodeVisited::Vector{Vector{Int64}}                  ->  contains the result of each search in term of node visited : number of nodes visited to 
                                                             find every solution or infeasible case of an instance.
+    solutionFound::Vector{Vector{Bool}}                 ->  contains the result of each search in term of solution found: true if the dead-end
+                                                            is a solution and false otherwise.
     meanNodeVisitedUntilfirstSolFound::Vector{Float32}  ->  contains the result of each search in term of node visited to find a first solution.
     meanNodeVisitedUntilEnd::Vector{Float32}            ->  contains the result of each search in term of node visited until the end of the search.
     timeneeded::Vector{Float32}                         ->  contains the computing time required to complete each search.
@@ -28,6 +30,7 @@ It satisfies the two AbstractMetrics requirements:
 mutable struct BasicMetrics{O<:AbstractTakeObjective, H<:ValueSelection} <: AbstractMetrics
     heuristic::H
     nodeVisited::Vector{Vector{Int64}}
+    solutionFound::Vector{Vector{Int64}}
     meanNodeVisitedUntilfirstSolFound::Vector{Float32}
     meanNodeVisitedUntilEnd::Vector{Float32}
     timeneeded::Vector{Float32}
@@ -37,7 +40,7 @@ mutable struct BasicMetrics{O<:AbstractTakeObjective, H<:ValueSelection} <: Abst
     meanOver::Int64
     nbEpisodes::Int64
 
-    BasicMetrics{O,H}(heuristic,meanOver) where {O,H}= new{O, H}(heuristic,Vector{Vector{Int64}}(),Float32[],Float32[], Float32[], O==TakeObjective ? Vector{Vector{Float32}}() : nothing, (H == BasicHeuristic) ? nothing : Float32[], (H == BasicHeuristic) ? nothing : Float32[], meanOver,0)
+    BasicMetrics{O,H}(heuristic,meanOver) where {O,H}= new{O, H}(heuristic,Vector{Vector{Int64}}(),Vector{Vector{Int64}}(),Float32[],Float32[], Float32[], O==TakeObjective ? Vector{Vector{Float32}}() : nothing, (H == BasicHeuristic) ? nothing : Float32[], (H == BasicHeuristic) ? nothing : Float32[], meanOver,0)
 end
 
 BasicMetrics(model::CPModel, heuristic::ValueSelection; meanOver=1) = BasicMetrics{(!isnothing(model.objective)) ? TakeObjective : DontTakeObjective ,typeof(heuristic)}(heuristic,meanOver)
@@ -51,6 +54,7 @@ It updates all the metrics during the search.
 function (metrics::BasicMetrics{DontTakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
+    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -62,6 +66,7 @@ end
 function (metrics::BasicMetrics{TakeObjective, <:BasicHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
+    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -76,6 +81,7 @@ end
 function (metrics::BasicMetrics{DontTakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64)
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
+    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])
@@ -90,6 +96,7 @@ end
 function (metrics::BasicMetrics{TakeObjective, <:LearnedHeuristic})(model::CPModel,dt::Float64) 
     metrics.nbEpisodes+=1
     push!(metrics.nodeVisited,copy(model.statistics.nodevisitedpersolution))
+    push!(metrics.solutionFound, (x -> isnothing(x) ? 0 : 1).(model.statistics.solutions))
     push!(metrics.meanNodeVisitedUntilEnd,model.statistics.numberOfNodes)
     if ! isempty(model.statistics.nodevisitedpersolution)    #infeasible case
         push!(metrics.meanNodeVisitedUntilfirstSolFound,model.statistics.nodevisitedpersolution[1])

--- a/test/experiment/basicmetrics.jl
+++ b/test/experiment/basicmetrics.jl
@@ -78,6 +78,7 @@ agent = RL.Agent(
 
         
         @test isempty(metrics.nodeVisited)== true
+        @test isempty(metrics.solutionFound) == true
         @test isempty(metrics.meanNodeVisitedUntilEnd) == true
         @test isempty(metrics.timeneeded) == true
         @test isnothing(metrics.scores) == true
@@ -136,6 +137,7 @@ agent = RL.Agent(
         metrics(model,dt)
 
         @test metrics.nodeVisited[1] == [2,3]
+        @test metrics.solutionFound[1] == [1, 1]
         @test size(metrics.timeneeded,1) == 1
         @test metrics.nbEpisodes == 1 
         
@@ -159,6 +161,7 @@ agent = RL.Agent(
 
 
         @test isempty(metrics.nodeVisited) == false #the number of solution found and their relative score depend on the stochastic heuristic...
+        @test isempty(metrics.solutionFound) == false
         @test metrics.nbEpisodes == 1 
         @test size(metrics.timeneeded,1) == 1
         @test size(metrics.totalReward,1) == 1
@@ -181,8 +184,31 @@ agent = RL.Agent(
         dt = @elapsed SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), basicheuristic) 
         metrics(model,dt)
 
-        @test metrics.nodeVisited[1] == [2, 3] #only one soluion found due to Objective prunning 
+        @test metrics.nodeVisited[1] == [2, 3]
+        @test metrics.solutionFound[1] == [1, 1]
         @test metrics.scores[1] == [3, 2] 
+        @test size(metrics.timeneeded,1) == 1
+        @test metrics.nbEpisodes == 1 
+    end
+
+    @testset "BasicMetrics{TakeObjective, BasicHeuristic} impossible" begin
+        trailer = SeaPearl.Trailer()
+        model = SeaPearl.CPModel(trailer)
+        basicheuristic = SeaPearl.BasicHeuristic()
+
+        x = SeaPearl.IntVar(2, 3, "x", trailer)
+        y = SeaPearl.IntVar(4, 5, "y", trailer)
+        SeaPearl.addVariable!(model, x)
+        SeaPearl.addVariable!(model, y)
+        SeaPearl.addConstraint!(model, SeaPearl.Equal(x, y, trailer))
+        SeaPearl.addObjective!(model,y)
+        metrics  = SeaPearl.BasicMetrics(model, basicheuristic)
+        dt = @elapsed SeaPearl.search!(model, SeaPearl.DFSearch(), SeaPearl.MinDomainVariableSelection(), basicheuristic) 
+        metrics(model,dt)
+
+        @test metrics.nodeVisited[1] == [1]
+        @test metrics.solutionFound[1] == [0]
+        @test metrics.scores[1] == [nothing] 
         @test size(metrics.timeneeded,1) == 1
         @test metrics.nbEpisodes == 1 
     end
@@ -205,6 +231,7 @@ agent = RL.Agent(
         metrics(model,dt)
 
         @test isempty(metrics.nodeVisited) == false #the number of solution found and their relative score depend on the stochastic heuristic...
+        @test isempty(metrics.solutionFound) == false 
         @test isempty(metrics.scores) == false 
         @test metrics.nbEpisodes == 1 
         @test size(metrics.timeneeded,1) == 1


### PR DESCRIPTION
Adds a `solutionFound` field in `model.statistics` to know if the dead-end corresponds to a solution or an infeasible state.